### PR TITLE
Don't restrict reading Options from YamlObjects

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
@@ -240,11 +240,12 @@ trait ProductFormats {
           deserializationError(msg, cause, fieldName :: fieldNames)
       }
 
-    case _ if isOption =>
+    case YamlNull if isOption =>
       None.asInstanceOf[A]
 
     case _ =>
-      deserializationError("YamlObject with '" + fieldName + "' expected",
+      deserializationError((if (isOption) "Either YamlNull or " else "") +
+        "YamlObject with '" + fieldName + "' expected",
         fieldNames = fieldName :: Nil)
   }
 }

--- a/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
@@ -240,8 +240,12 @@ trait ProductFormats {
           deserializationError(msg, cause, fieldName :: fieldNames)
       }
 
-    case _ => deserializationError("YamlObject expected in field '" + fieldName
-      + "'", fieldNames = fieldName :: Nil)
+    case _ if isOption =>
+      None.asInstanceOf[A]
+
+    case _ =>
+      deserializationError("YamlObject with '" + fieldName + "' expected",
+        fieldNames = fieldName :: Nil)
   }
 }
 


### PR DESCRIPTION
The previous `readField` implementation was expecting to read `Option` values always from `YamlObjects`. I believe that shouldn't be enforced. This change avoids deserialization errors in cases the provided `YamlValue` isn't an `YamlObject`. 

This allows, for instance, to deserialize an empty YAML document into a product with all optional fields.
