### PR TITLE
Allow reading `YamlBoolean` and `YamlNumber` as strings

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/BasicFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/BasicFormats.scala
@@ -115,6 +115,8 @@ trait BasicFormats {
     }
     def read(value: YamlValue) = value match {
       case YamlString(x) => x
+      case YamlBoolean(x) => x.toString
+      case YamlNumber(x) => x.toString()
       case x =>
         deserializationError("Expected String as YamlString, but got " + x)
     }

--- a/src/main/scala/net/jcazevedo/moultingyaml/BasicFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/BasicFormats.scala
@@ -116,7 +116,7 @@ trait BasicFormats {
     def read(value: YamlValue) = value match {
       case YamlString(x) => x
       case YamlBoolean(x) => x.toString
-      case YamlNumber(x) => x.toString()
+      case YamlNumber(x) => x.toString
       case x =>
         deserializationError("Expected String as YamlString, but got " + x)
     }

--- a/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
@@ -182,6 +182,18 @@ class BasicFormatsSpec extends Specification with BasicFormats {
     "convert a YamlString to a String" in {
       YamlString("Hello").convertTo[String] mustEqual "Hello"
     }
+
+    "allow converting a YamlBoolean to a String" in {
+      StringYamlFormat.read(YamlBoolean(true)) mustEqual "true"
+      StringYamlFormat.read(YamlBoolean(false)) mustEqual "false"
+    }
+
+    "allow converting a YamlNumber to a String" in {
+      StringYamlFormat.read(YamlNumber(42)) mustEqual "42"
+      StringYamlFormat.read(YamlNumber(4.2)) mustEqual "4.2"
+      StringYamlFormat.read(YamlNumber(BigDecimal(4.2))) mustEqual "4.2"
+      StringYamlFormat.read(YamlNumber(BigInt(42))) mustEqual "42"
+    }
   }
 
   "The SymbolYamlFormat" should {

--- a/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
@@ -38,7 +38,7 @@ class StandardFormatsSpec extends Specification with StandardFormats
     }
 
     "convert the left side of an Either value from a YamlValue" in {
-      YamlNumber(42).convertTo[Either[Int, String]] mustEqual Left(42)
+      YamlNumber(42).convertTo[Either[Int, Boolean]] mustEqual Left(42)
     }
 
     "convert the right side of an Either value from a YamlValue" in {


### PR DESCRIPTION
Since YAML doesn't require strings to be enclosed in quotes, the `StringYamlFormat` should also be able to read strings from (at least) booleans and numbers.

The same problem arises with dates and nulls. The latter can be converted to the string `"null"`, but the former requires one to store the original date representation in string format, since by the time we're formatting it it already is a `YamlDate`. What's your opinion on this?
