### PR TITLE
Improve deserialization exception message when expecting a `YamlObject`

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
@@ -240,8 +240,9 @@ trait ProductFormats {
           deserializationError(msg, cause, fieldName :: fieldNames)
       }
 
-    case _ => deserializationError("YamlObject expected in field '" + fieldName
-      + "'", fieldNames = fieldName :: Nil)
+    case other =>
+      deserializationError("YamlObject expected, but got " + other,
+        fieldNames = fieldName :: Nil)
   }
 }
 


### PR DESCRIPTION
This pull request improves the message associated with the deserialization exception that arises when a `YamlObject` was expected, but we got something else instead.

This fixes #1.
