### PR TITLE
Support yamlFormat 8 to 22

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
@@ -61,6 +61,111 @@ trait ProductFormats {
     yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7)
   }
 
+  def yamlFormat8[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8)
+  }
+
+  def yamlFormat9[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9)
+  }
+
+  def yamlFormat10[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+  }
+
+  def yamlFormat11[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)
+  }
+
+  def yamlFormat12[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+  }
+
+  def yamlFormat13[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
+  }
+
+  def yamlFormat14[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
+  }
+
+  def yamlFormat15[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
+  }
+
+  def yamlFormat16[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
+  }
+
+  def yamlFormat17[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
+  }
+
+  def yamlFormat18[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
+  }
+
+  def yamlFormat19[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
+  }
+
+  def yamlFormat20[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, U: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
+  }
+
+  def yamlFormat21[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, U: YF, V: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
+  }
+
+  def yamlFormat22[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, U: YF, V: YF, X: YF, T <: Product: WeakTypeTag](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, X) => T): YF[T] = {
+
+    val List(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22) = fieldInfo[T]
+    yamlFormat(construct, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22)
+  }
+
   def yamlFormat[A: YF, T <: Product](
     construct: A => T, field1: (String, Boolean)) = new YF[T] {
 
@@ -204,6 +309,730 @@ trait ProductFormats {
       readField[E](value, field5._1, field5._2),
       readField[F](value, field6._1, field6._2),
       readField[G](value, field7._1, field7._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean),
+    field16: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2),
+        writeField[P](p.productElement(15), field16._1, field16._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2),
+      readField[P](value, field16._1, field16._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean),
+    field16: (String, Boolean), field17: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2),
+        writeField[P](p.productElement(15), field16._1, field16._2),
+        writeField[Q](p.productElement(16), field17._1, field17._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2),
+      readField[P](value, field16._1, field16._2),
+      readField[Q](value, field17._1, field17._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean),
+    field16: (String, Boolean), field17: (String, Boolean),
+    field18: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2),
+        writeField[P](p.productElement(15), field16._1, field16._2),
+        writeField[Q](p.productElement(16), field17._1, field17._2),
+        writeField[R](p.productElement(17), field18._1, field18._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2),
+      readField[P](value, field16._1, field16._2),
+      readField[Q](value, field17._1, field17._2),
+      readField[R](value, field18._1, field18._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean),
+    field16: (String, Boolean), field17: (String, Boolean),
+    field18: (String, Boolean), field19: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2),
+        writeField[P](p.productElement(15), field16._1, field16._2),
+        writeField[Q](p.productElement(16), field17._1, field17._2),
+        writeField[R](p.productElement(17), field18._1, field18._2),
+        writeField[S](p.productElement(18), field19._1, field19._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2),
+      readField[P](value, field16._1, field16._2),
+      readField[Q](value, field17._1, field17._2),
+      readField[R](value, field18._1, field18._2),
+      readField[S](value, field19._1, field19._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, U: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean),
+    field16: (String, Boolean), field17: (String, Boolean),
+    field18: (String, Boolean), field19: (String, Boolean),
+    field20: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2),
+        writeField[P](p.productElement(15), field16._1, field16._2),
+        writeField[Q](p.productElement(16), field17._1, field17._2),
+        writeField[R](p.productElement(17), field18._1, field18._2),
+        writeField[S](p.productElement(18), field19._1, field19._2),
+        writeField[U](p.productElement(19), field20._1, field20._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2),
+      readField[P](value, field16._1, field16._2),
+      readField[Q](value, field17._1, field17._2),
+      readField[R](value, field18._1, field18._2),
+      readField[S](value, field19._1, field19._2),
+      readField[U](value, field20._1, field20._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, U: YF, V: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean),
+    field16: (String, Boolean), field17: (String, Boolean),
+    field18: (String, Boolean), field19: (String, Boolean),
+    field20: (String, Boolean), field21: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2),
+        writeField[P](p.productElement(15), field16._1, field16._2),
+        writeField[Q](p.productElement(16), field17._1, field17._2),
+        writeField[R](p.productElement(17), field18._1, field18._2),
+        writeField[S](p.productElement(18), field19._1, field19._2),
+        writeField[U](p.productElement(19), field20._1, field20._2),
+        writeField[V](p.productElement(20), field21._1, field21._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2),
+      readField[P](value, field16._1, field16._2),
+      readField[Q](value, field17._1, field17._2),
+      readField[R](value, field18._1, field18._2),
+      readField[S](value, field19._1, field19._2),
+      readField[U](value, field20._1, field20._2),
+      readField[V](value, field21._1, field21._2))
+  }
+
+  def yamlFormat[A: YF, B: YF, C: YF, D: YF, E: YF, F: YF, G: YF, H: YF, I: YF, J: YF, K: YF, L: YF, M: YF, N: YF, O: YF, P: YF, Q: YF, R: YF, S: YF, U: YF, V: YF, X: YF, T <: Product](
+    construct: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, U, V, X) => T, field1: (String, Boolean),
+    field2: (String, Boolean), field3: (String, Boolean),
+    field4: (String, Boolean), field5: (String, Boolean),
+    field6: (String, Boolean), field7: (String, Boolean),
+    field8: (String, Boolean), field9: (String, Boolean),
+    field10: (String, Boolean), field11: (String, Boolean),
+    field12: (String, Boolean), field13: (String, Boolean),
+    field14: (String, Boolean), field15: (String, Boolean),
+    field16: (String, Boolean), field17: (String, Boolean),
+    field18: (String, Boolean), field19: (String, Boolean),
+    field20: (String, Boolean), field21: (String, Boolean),
+    field22: (String, Boolean)) = new YF[T] {
+
+    def write(p: T) = {
+      val fields = Seq(
+        writeField[A](p.productElement(0), field1._1, field1._2),
+        writeField[B](p.productElement(1), field2._1, field2._2),
+        writeField[C](p.productElement(2), field3._1, field3._2),
+        writeField[D](p.productElement(3), field4._1, field4._2),
+        writeField[E](p.productElement(4), field5._1, field5._2),
+        writeField[F](p.productElement(5), field6._1, field6._2),
+        writeField[G](p.productElement(6), field7._1, field7._2),
+        writeField[H](p.productElement(7), field8._1, field8._2),
+        writeField[I](p.productElement(8), field9._1, field9._2),
+        writeField[J](p.productElement(9), field10._1, field10._2),
+        writeField[K](p.productElement(10), field11._1, field11._2),
+        writeField[L](p.productElement(11), field12._1, field12._2),
+        writeField[M](p.productElement(12), field13._1, field13._2),
+        writeField[N](p.productElement(13), field14._1, field14._2),
+        writeField[O](p.productElement(14), field15._1, field15._2),
+        writeField[P](p.productElement(15), field16._1, field16._2),
+        writeField[Q](p.productElement(16), field17._1, field17._2),
+        writeField[R](p.productElement(17), field18._1, field18._2),
+        writeField[S](p.productElement(18), field19._1, field19._2),
+        writeField[U](p.productElement(19), field20._1, field20._2),
+        writeField[V](p.productElement(20), field21._1, field21._2),
+        writeField[X](p.productElement(21), field22._1, field22._2))
+      YamlObject(fields.flatten: _*)
+    }
+
+    def read(value: YamlValue) = construct(
+      readField[A](value, field1._1, field1._2),
+      readField[B](value, field2._1, field2._2),
+      readField[C](value, field3._1, field3._2),
+      readField[D](value, field4._1, field4._2),
+      readField[E](value, field5._1, field5._2),
+      readField[F](value, field6._1, field6._2),
+      readField[G](value, field7._1, field7._2),
+      readField[H](value, field8._1, field8._2),
+      readField[I](value, field9._1, field9._2),
+      readField[J](value, field10._1, field10._2),
+      readField[K](value, field11._1, field11._2),
+      readField[L](value, field12._1, field12._2),
+      readField[M](value, field13._1, field13._2),
+      readField[N](value, field14._1, field14._2),
+      readField[O](value, field15._1, field15._2),
+      readField[P](value, field16._1, field16._2),
+      readField[Q](value, field17._1, field17._2),
+      readField[R](value, field18._1, field18._2),
+      readField[S](value, field19._1, field19._2),
+      readField[U](value, field20._1, field20._2),
+      readField[V](value, field21._1, field21._2),
+      readField[X](value, field22._1, field22._2))
   }
 
   private[this] def fieldInfo[T: WeakTypeTag]: List[(String, Boolean)] =

--- a/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
@@ -8,6 +8,9 @@ class ProductFormatsSpec extends Specification {
   case class Test2(a: Int, b: Option[Double])
   case class Test3[A, B](as: List[A], bs: List[B])
   case class Test4(t2: Test2)
+  case class Test5(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int,
+                   a10: Int, a11: Int, a12: Int, a13: Int, a14: Int, a15: Int, a16: Int, a17: Int,
+                   a18: Int, a19: Int, a20: Int, a21: Int, a22: Int)
   case class TestTransient(a: Int, b: Option[Double]) {
     @transient var c = false
   }
@@ -24,6 +27,7 @@ class ProductFormatsSpec extends Specification {
     implicit def test3Format[A: YamlFormat, B: YamlFormat] =
       yamlFormat2(Test3.apply[A, B])
     implicit val test4Format = yamlFormat1(Test4)
+    implicit val test5Format = yamlFormat22(Test5)
     implicit val testTransientFormat = yamlFormat2(TestTransient)
     implicit val testStaticFormat = yamlFormat2(TestStatic)
     implicit val testMangledFormat = yamlFormat5(TestMangled)
@@ -198,6 +202,40 @@ class ProductFormatsSpec extends Specification {
     "convert a YamlObject to the respective case class instance" in {
       yaml.parseYaml.convertTo[TestMangled] mustEqual
         TestMangled(42, "Karl", true, 26, 1.0f)
+    }
+  }
+
+  "A YamlFormat created with `yamlFormat`, for a case class with 22 elements," should {
+    val obj = Test5(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
+    val yaml = YamlObject(YamlString("a1") -> YamlNumber(1),
+      YamlString("a2") -> YamlNumber(2),
+      YamlString("a3") -> YamlNumber(3),
+      YamlString("a4") -> YamlNumber(4),
+      YamlString("a5") -> YamlNumber(5),
+      YamlString("a6") -> YamlNumber(6),
+      YamlString("a7") -> YamlNumber(7),
+      YamlString("a8") -> YamlNumber(8),
+      YamlString("a9") -> YamlNumber(9),
+      YamlString("a10") -> YamlNumber(10),
+      YamlString("a11") -> YamlNumber(11),
+      YamlString("a12") -> YamlNumber(12),
+      YamlString("a13") -> YamlNumber(13),
+      YamlString("a14") -> YamlNumber(14),
+      YamlString("a15") -> YamlNumber(15),
+      YamlString("a16") -> YamlNumber(16),
+      YamlString("a17") -> YamlNumber(17),
+      YamlString("a18") -> YamlNumber(18),
+      YamlString("a19") -> YamlNumber(19),
+      YamlString("a20") -> YamlNumber(20),
+      YamlString("a21") -> YamlNumber(21),
+      YamlString("a22") -> YamlNumber(22))
+
+    "convert to a respective YamlObject" in {
+      obj.toYaml mustEqual yaml
+    }
+
+    "convert a YamlObject to the respective case class instance" in {
+      yaml.convertTo[Test5] mustEqual obj
     }
   }
 }


### PR DESCRIPTION
Eventually this could be changed to a macro or using a boilerplate template like spray-json [does](https://github.com/spray/spray-json/blob/master/src/main/boilerplate/spray/json/ProductFormatsInstances.scala.template).
