### PR TITLE
PR for discussion: how to read a YamlNumber either as Int or as Double

### DIFF
--- a/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
@@ -105,6 +105,9 @@ class BasicFormatsSpec extends Specification with BasicFormats {
 
         // "scala.MatchError: YamlNumber(42)"
         //case YamlNumber(d: Double) => Try(d.toInt).getOrElse(d)
+
+        // No access
+        //case v @ YamlNumber(x) => v.num.toInt(x)
       }
 
       outA.getClass.getSimpleName mustEqual "int"

--- a/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
@@ -3,6 +3,8 @@ package net.jcazevedo.moultingyaml
 import com.github.nscala_time.time.Imports._
 import org.specs2.mutable._
 
+import scala.util.Try
+
 class BasicFormatsSpec extends Specification with BasicFormats {
 
   "The IntYamlFormat" should {
@@ -85,6 +87,28 @@ class BasicFormatsSpec extends Specification with BasicFormats {
 
     "convert a YamlNull to a Double" in {
       YamlNull.convertTo[Double].isNaN mustEqual Double.NaN.isNaN
+    }
+  }
+
+  "The YamlNumber" should {
+    val nums = Seq(YamlNumber(42), YamlNumber(4.2))
+
+    "be convertible to an Int as well as a Double" in {
+      val Seq(outA, outB) = nums.map {
+        // Causes 'double' instead of the 'int'
+        case YamlNumber(x: Int) => x.toInt
+        case YamlNumber(x: Double) => x
+
+        // "scala.MatchError: YamlNumber(42)"
+        //case YamlNumber(x: Double) if x.isValidInt => x.toInt
+        //case YamlNumber(x: Double) => x
+
+        // "scala.MatchError: YamlNumber(42)"
+        //case YamlNumber(d: Double) => Try(d.toInt).getOrElse(d)
+      }
+
+      outA.getClass.getSimpleName mustEqual "int"
+      outB.getClass.getSimpleName mustEqual "double"
     }
   }
 


### PR DESCRIPTION
In order to do YAML<->JSON conversion, I need to read YamlNumber that can carry either Int or Double, and convert them differently.

After having elaborately studied the source, and its differences with spray.json (which I'm familiar with), I still cannot get this to work.

Would you please suggest a way that works.

Below code shows three different things I've tried. One seems to ignore the `Int` and it gets converted to a `Double`. The other ones (if there is no case for `YamlNumber(x: Int)`, claim they cannot match `YamlNumber(42)`.

The code that [MoultingYaml itself](https://github.com/jcazevedo/moultingyaml/blob/17f7e19b917e8ce027710d11028b9194956e0b46/src/main/scala/net/jcazevedo/moultingyaml/BasicFormats.scala#L13) has uses `.num` which is not available outside of the library. 