### PR TITLE
allows custom printers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ensime
 .ensime_cache
+.idea
 target/

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
@@ -85,11 +85,16 @@ class SnakeYamlPrinter(flowStyle: FlowStyle,
                        scalarStyle: ScalarStyle,
                        lineBreak: LineBreak)
     extends YamlPrinter(flowStyle, scalarStyle, lineBreak) {
-  override def apply(value: YamlValue): String = {
+
+  def dumperOptions : DumperOptions = {
     val dp = new DumperOptions
     dp.setDefaultScalarStyle(scalarStyle.toDumperOption)
     dp.setDefaultFlowStyle(flowStyle.toDumperOption)
     dp.setLineBreak(lineBreak.toDumperOption)
-    new Yaml(dp).dump(value.snakeYamlObject)
+    dp
+  }
+
+  override def apply(value: YamlValue): String = {
+    new Yaml(dumperOptions).dump(value.snakeYamlObject)
   }
 }

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
@@ -81,9 +81,9 @@ abstract class YamlPrinter(
   def apply(value: YamlValue): String
 }
 
-class SnakeYamlPrinter(flowStyle: FlowStyle,
-                       scalarStyle: ScalarStyle,
-                       lineBreak: LineBreak)
+class SnakeYamlPrinter(flowStyle: FlowStyle = FlowStyle.DEFAULT,
+                       scalarStyle: ScalarStyle = ScalarStyle.DEFAULT,
+                       lineBreak: LineBreak = LineBreak.DEFAULT)
     extends YamlPrinter(flowStyle, scalarStyle, lineBreak) {
 
   def dumperOptions : DumperOptions = {

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
@@ -86,7 +86,7 @@ class SnakeYamlPrinter(flowStyle: FlowStyle = FlowStyle.DEFAULT,
                        lineBreak: LineBreak = LineBreak.DEFAULT)
     extends YamlPrinter(flowStyle, scalarStyle, lineBreak) {
 
-  def dumperOptions : DumperOptions = {
+  def dumperOptions: DumperOptions = {
     val dp = new DumperOptions
     dp.setDefaultScalarStyle(scalarStyle.toDumperOption)
     dp.setDefaultFlowStyle(flowStyle.toDumperOption)

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -23,7 +23,7 @@ sealed abstract class YamlValue {
 
   def prettyPrint: String = print()
 
-  def print(yamlPrinter: YamlPrinter) : String = yamlPrinter(this)
+  def print(implicit yamlPrinter: YamlPrinter): String = yamlPrinter(this)
 }
 
 /**

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -1,7 +1,7 @@
 package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
  * The general type of a YAML AST node.
@@ -15,15 +15,13 @@ sealed abstract class YamlValue {
 
   private[moultingyaml] def snakeYamlObject: Object
 
-  def print(flowStyle: FlowStyle = FlowStyle.DEFAULT,
-            scalarStyle: ScalarStyle = ScalarStyle.DEFAULT,
-            lineBreak: LineBreak = LineBreak.DEFAULT) : String = {
-    print(new SnakeYamlPrinter(flowStyle, scalarStyle, lineBreak))
-  }
-
-  def prettyPrint: String = print()
+  def prettyPrint: String = print(YamlValue.implicitSnakeYamlPrinter)
 
   def print(implicit yamlPrinter: YamlPrinter): String = yamlPrinter(this)
+}
+
+object YamlValue {
+  implicit val implicitSnakeYamlPrinter = new SnakeYamlPrinter
 }
 
 /**

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -17,12 +17,13 @@ sealed abstract class YamlValue {
 
   def print(flowStyle: FlowStyle = FlowStyle.DEFAULT,
             scalarStyle: ScalarStyle = ScalarStyle.DEFAULT,
-            lineBreak: LineBreak = LineBreak.DEFAULT) = {
-    val printer = new SnakeYamlPrinter(flowStyle, scalarStyle, lineBreak)
-    printer(this)
+            lineBreak: LineBreak = LineBreak.DEFAULT) : String = {
+    print(new SnakeYamlPrinter(flowStyle, scalarStyle, lineBreak))
   }
 
   def prettyPrint: String = print()
+
+  def print(yamlPrinter: YamlPrinter) : String = yamlPrinter(this)
 }
 
 /**

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -1,7 +1,7 @@
 package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
  * The general type of a YAML AST node.

--- a/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
@@ -243,7 +243,7 @@ class YamlPrettyPrinterSpec extends Specification {
         YamlString("bigint_canonical") ->
           YamlNumber(BigInt("92233720368547758070")))
 
-      yaml.print(scalarStyle = DoubleQuoted) mustEqual
+      yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)) mustEqual
         """"int": !!int "42"
           |"float": !!float "0.4555"
           |"long_canonical": !!int "21474836470"
@@ -262,8 +262,8 @@ class YamlPrettyPrinterSpec extends Specification {
         YamlString("bigint_canonical") ->
           YamlNumber(BigInt("92233720368547758070")))
 
-      yaml.print(scalarStyle = DoubleQuoted) mustEqual
-        yaml.print(scalarStyle = ScalarStyle.createStyle('"'))
+      yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)) mustEqual
+        yaml.print(new SnakeYamlPrinter(scalarStyle = ScalarStyle.createStyle('"')))
     }
 
     "print with default configuration" in {
@@ -277,7 +277,7 @@ class YamlPrettyPrinterSpec extends Specification {
         YamlString("bigint_canonical") ->
           YamlNumber(BigInt("92233720368547758070")))
 
-      yaml.print() mustEqual yaml.prettyPrint
+      yaml.print mustEqual yaml.prettyPrint
     }
 
     "print can use an implicit YamlPrinter" in {
@@ -293,7 +293,7 @@ class YamlPrettyPrinterSpec extends Specification {
 
       implicit val yamlPrinter = new SnakeYamlPrinter(scalarStyle = DoubleQuoted)
 
-      yaml.print mustEqual yaml.print(scalarStyle = DoubleQuoted)
+      yaml.print mustEqual yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted))
     }
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
@@ -279,5 +279,21 @@ class YamlPrettyPrinterSpec extends Specification {
 
       yaml.print() mustEqual yaml.prettyPrint
     }
+
+    "print can use an implicit YamlPrinter" in {
+      val yaml = YamlObject(
+        YamlString("int") ->
+          YamlNumber(42),
+        YamlString("float") ->
+          YamlNumber(0.4555),
+        YamlString("long_canonical") ->
+          YamlNumber(21474836470L),
+        YamlString("bigint_canonical") ->
+          YamlNumber(BigInt("92233720368547758070")))
+
+      implicit val yamlPrinter = new SnakeYamlPrinter(scalarStyle = DoubleQuoted)
+
+      yaml.print mustEqual yaml.print(scalarStyle = DoubleQuoted)
+    }
   }
 }


### PR DESCRIPTION
Added a new print function that accept a YamlPrinter parameter, so it is possible to use a custom printer.

YamlPrinter could be implicit.

SnakeYamlPrinter expose DumperOption as a method so it can be extended to build custom printers, added default values.