### PR TITLE
Add parsing support for +/-Inf w/ tests

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/BasicFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/BasicFormats.scala
@@ -30,6 +30,8 @@ trait BasicFormats {
     def read(value: YamlValue) = value match {
       case YamlNumber(x) => x.floatValue
       case YamlNull => Float.NaN
+      case YamlPositiveInf => Float.PositiveInfinity
+      case YamlNegativeInf => Float.NegativeInfinity
       case x =>
         deserializationError("Expected Float as YamlNumber, but got " + x)
     }
@@ -40,6 +42,8 @@ trait BasicFormats {
     def read(value: YamlValue) = value match {
       case YamlNumber(x) => x.doubleValue
       case YamlNull => Double.NaN
+      case YamlPositiveInf => Double.PositiveInfinity
+      case YamlNegativeInf => Double.NegativeInfinity
       case x =>
         deserializationError("Expected Double as YamlNumber, but got " + x)
     }

--- a/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
@@ -53,6 +53,14 @@ class BasicFormatsSpec extends Specification with BasicFormats {
     "convert a YamlNull to a Float" in {
       YamlNull.convertTo[Float].isNaN mustEqual Float.NaN.isNaN
     }
+
+    "convert a YamlPositiveInf to a Float" in {
+      YamlPositiveInf.convertTo[Float] mustEqual Float.PositiveInfinity
+    }
+
+    "convert a YamlNegativeInf to a Float" in {
+      YamlNegativeInf.convertTo[Float] mustEqual Float.NegativeInfinity
+    }
   }
 
   "The DoubleYamlFormat" should {
@@ -81,6 +89,14 @@ class BasicFormatsSpec extends Specification with BasicFormats {
 
     "convert a YamlNull to a Double" in {
       YamlNull.convertTo[Double].isNaN mustEqual Double.NaN.isNaN
+    }
+
+    "convert a YamlPositiveInf to a Double" in {
+      YamlPositiveInf.convertTo[Double] mustEqual Double.PositiveInfinity
+    }
+
+    "convert a YamlNegativeInf to a Double" in {
+      YamlNegativeInf.convertTo[Double] mustEqual Double.NegativeInfinity
     }
   }
 


### PR DESCRIPTION
Currently it is impossible to parse infinities in a YAML. I get the following error:
`Exception in thread "main" net.jcazevedo.moultingyaml.package$DeserializationException: Expected Double as YamlNumber, but got YamlPositiveInf`

This PR enables correct parsing of infinities and adds the appropriate test cases.