### PR TITLE
Dockerize the tests so that they are easily reproducible.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/target
+.git
+.gitignore
+.travis.yml
+Dockerfile
+LICENSE.md
+README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,7 @@
 sudo: required
 services:
   - docker
-language: scala
-scala:
-  - 2.12.0
-  - 2.11.8
-  - 2.10.6
-jdk:
-  - oraclejdk8
 before_install:
-  - docker build --build-arg SCALA_VERSION=$TRAVIS_SCALA_VERSION -t moultingyaml:test .
-script: |
-  if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then
-    docker run --rm -it moultingyaml:test sbt test ++$TRAVIS_SCALA_VERSION clean coverage test
-  else
-    docker run --rm -it moultingyaml:test sbt test ++$TRAVIS_SCALA_VERSION clean test
-  fi
-after_success: |
-  if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then
-    docker run --rm -it moultingyaml:test sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
-  fi  
+  - docker build -t moultingyaml:test .
+script: docker run --rm -it moultingyaml:test sbt coverage +test
+after_success: docker run --rm -it moultingyaml:test sbt coverageReport coverageAggregate coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+services:
+  - docker
 language: scala
 scala:
   - 2.12.0
@@ -5,17 +8,15 @@ scala:
   - 2.10.6
 jdk:
   - oraclejdk8
+before_install:
+  - docker build --build-arg SCALA_VERSION=$TRAVIS_SCALA_VERSION -t moultingyaml:test .
 script: |
   if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then
-    sbt ++$TRAVIS_SCALA_VERSION clean coverage test
+    docker run --rm -it moultingyaml:test sbt test ++$TRAVIS_SCALA_VERSION clean coverage test
   else
-    sbt ++$TRAVIS_SCALA_VERSION clean test
+    docker run --rm -it moultingyaml:test sbt test ++$TRAVIS_SCALA_VERSION clean test
   fi
 after_success: |
   if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then
-    sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
+    docker run --rm -it moultingyaml:test sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
   fi  
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,14 @@ WORKDIR /app
 
 # Cache the SBT JARs in a layer.
 COPY project/build.properties project/
-RUN sbt update
-
-ARG SCALA_VERSION=2.11.8
+RUN sbt +update
 
 # Cache the project-specific JARs.
 COPY project/*.sbt ./project
 COPY build.sbt .
-RUN sbt ++$SCALA_VERSION update
+RUN sbt +update
 
 # Copy the rest of the files. dockerignore should skip the files we don't want.
 COPY . ./
-RUN sbt ++$SCALA_VERSION compile
+RUN sbt +compile
+RUN sbt +test:compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM aa8y/sbt:1.0
+
+RUN mkdir -p /app/project
+WORKDIR /app
+
+# Cache the SBT JARs in a layer.
+COPY project/build.properties project/
+RUN sbt update
+
+ARG SCALA_VERSION=2.11.8
+
+# Cache the project-specific JARs.
+COPY project/*.sbt ./project
+COPY build.sbt .
+RUN sbt ++$SCALA_VERSION update
+
+# Copy the rest of the files. dockerignore should skip the files we don't want.
+COPY . ./
+RUN sbt ++$SCALA_VERSION compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,33 @@
 FROM aa8y/sbt:1.0
 
-RUN mkdir -p /app/project
-WORKDIR /app
+ARG APP_DIR=/app
+
+USER root
+RUN mkdir $APP_DIR
+RUN chown -R docker:docker $APP_DIR
+WORKDIR $APP_DIR
 
 # Cache the SBT JARs in a layer.
+USER docker
+RUN mkdir project
 COPY project/build.properties project/
+USER root
+RUN chown -R docker:docker project
+USER docker
 RUN sbt +update
 
 # Cache the project-specific JARs.
 COPY project/*.sbt ./project
 COPY build.sbt .
+USER root
+RUN chown -R docker:docker .
+USER docker
 RUN sbt +update
 
 # Copy the rest of the files. dockerignore should skip the files we don't want.
 COPY . ./
+USER root
+RUN chown -R docker:docker .
+USER docker
 RUN sbt +compile
 RUN sbt +test:compile

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.4.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")


### PR DESCRIPTION
- Dockerizes tests to make it easier to reproduce them on different machines.
- Makes travis run tests using docker for consistency. SBT's cross-version features are used to run tests for all Scala versions.
- `sbt-scoverage` has been upgraded _only_ because it failed to pull `scalac-scoverage-plugin` for `1.2.0` which seems to have been used before in `1.4.0` for `sbt-scoverage`.
