### PR TITLE
Readers and Writers for collections for recursive definitions

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/CollectionReaders.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/CollectionReaders.scala
@@ -1,0 +1,98 @@
+package net.jcazevedo.moultingyaml
+
+import scala.reflect.ClassTag
+
+/**
+ * Provides the YamlReaders for the most important Scala collections.
+ */
+trait CollectionReaders {
+
+  /**
+   * Supplies the YamlReader for Lists.
+   */
+  implicit def listReader[A: YR] = new YR[List[A]] {
+    def read(value: YamlValue): List[A] = value match {
+      case YamlArray(elements) =>
+        elements.map(_.convertTo[A])(collection.breakOut)
+      case x =>
+        deserializationError("Expected List as YamlArray, but got " + x)
+    }
+  }
+
+  /**
+   * Supplies the YamlReader for Arrays.
+   */
+  implicit def arrayReader[A: YR: ClassTag] = new YR[Array[A]] {
+    def read(value: YamlValue) = value match {
+      case YamlArray(elements) => elements.map(_.convertTo[A]).toArray
+      case x =>
+        deserializationError("Expected Array as YamlArray, but got " + x)
+    }
+  }
+
+  /**
+   * Supplies the YamlReader for Sets.
+   */
+  implicit def setReader[A: YR] = new YR[Set[A]] {
+    def read(value: YamlValue): Set[A] = value match {
+      case YamlSet(elements) => elements.map(_.convertTo[A])
+      case x =>
+        deserializationError("Expected Set as YamlSet, but got " + x)
+    }
+  }
+
+  /**
+   * Supplies the YamlReader for Maps.
+   */
+  implicit def mapReader[K: YR, V: YR] = new YR[Map[K, V]] {
+    def read(value: YamlValue) = value match {
+      case x: YamlObject =>
+        x.fields.map { case (k, v) => k.convertTo[K] -> v.convertTo[V] }
+      case x =>
+        deserializationError("Expected Map as YamlObject, but got " + x)
+    }
+  }
+
+  import collection.{ immutable => imm }
+
+  implicit def immIterableReader[T: YR] =
+    viaSeq[imm.Iterable[T], T](seq => imm.Iterable(seq: _*))
+
+  implicit def immSeqReader[T: YR] =
+    viaSeq[imm.Seq[T], T](seq => imm.Seq(seq: _*))
+
+  implicit def immIndexedSeqReader[T: YR] =
+    viaSeq[imm.IndexedSeq[T], T](seq => imm.IndexedSeq(seq: _*))
+
+  implicit def immLinearSeqReader[T: YR] =
+    viaSeq[imm.LinearSeq[T], T](seq => imm.LinearSeq(seq: _*))
+
+  implicit def vectorReader[T: YR] =
+    viaSeq[Vector[T], T](seq => Vector(seq: _*))
+
+  import collection._
+
+  implicit def iterableReader[T: YR] =
+    viaSeq[Iterable[T], T](seq => Iterable(seq: _*))
+
+  implicit def seqReader[T: YR] =
+    viaSeq[Seq[T], T](seq => Seq(seq: _*))
+
+  implicit def indexedSeqReader[T: YR] =
+    viaSeq[IndexedSeq[T], T](seq => IndexedSeq(seq: _*))
+
+  implicit def linearSeqReader[T: YR] =
+    viaSeq[LinearSeq[T], T](seq => LinearSeq(seq: _*))
+
+  /**
+   * A YamlReader construction helper that creates a YamlReader for an Iterable
+   * type I from a builder function List => I
+   */
+  def viaSeq[I <: Iterable[T], T: YR](f: imm.Seq[T] => I): YR[I] = new YR[I] {
+    def read(value: YamlValue) = value match {
+      case YamlArray(elements) => f(elements.map(_.convertTo[T]))
+      case x =>
+        deserializationError("Expected Collection as YamlArray, but got " + x)
+    }
+  }
+}

--- a/src/main/scala/net/jcazevedo/moultingyaml/CollectionWriters.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/CollectionWriters.scala
@@ -1,0 +1,77 @@
+package net.jcazevedo.moultingyaml
+
+import scala.reflect.ClassTag
+
+/**
+ * Provides the YamlWriters for the most important Scala collections.
+ */
+trait CollectionWriters {
+
+  /**
+   * Supplies the YamlWriter for Lists.
+   */
+  implicit def listWriter[A: YW] = new YW[List[A]] {
+    def write(list: List[A]) = YamlArray(list.map(_.toYaml).toVector)
+  }
+
+  /**
+   * Supplies the YamlWriter for Arrays.
+   */
+  implicit def arrayWriter[A: YW: ClassTag] = new YW[Array[A]] {
+    def write(array: Array[A]) = YamlArray(array.map(_.toYaml).toVector)
+  }
+
+  /**
+   * Supplies the YamlWriter for Sets.
+   */
+  implicit def setWriter[A: YW] = new YW[Set[A]] {
+    def write(set: Set[A]) = YamlSet(set.map(_.toYaml))
+  }
+
+  /**
+   * Supplies the YamlWriter for Maps.
+   */
+  implicit def mapWriter[K: YW, V: YW] = new YW[Map[K, V]] {
+    def write(m: Map[K, V]) =
+      YamlObject(m.map { case (k, v) => k.toYaml -> v.toYaml })
+  }
+
+  import collection.{ immutable => imm }
+
+  implicit def immIterableWriter[T: YW] =
+    viaSeq[imm.Iterable[T], T](seq => imm.Iterable(seq: _*))
+
+  implicit def immSeqWriter[T: YW] =
+    viaSeq[imm.Seq[T], T](seq => imm.Seq(seq: _*))
+
+  implicit def immIndexedSeqWriter[T: YW] =
+    viaSeq[imm.IndexedSeq[T], T](seq => imm.IndexedSeq(seq: _*))
+
+  implicit def immLinearSeqWriter[T: YW] =
+    viaSeq[imm.LinearSeq[T], T](seq => imm.LinearSeq(seq: _*))
+
+  implicit def vectorWriter[T: YW] =
+    viaSeq[Vector[T], T](seq => Vector(seq: _*))
+
+  import collection._
+
+  implicit def iterableWriter[T: YW] =
+    viaSeq[Iterable[T], T](seq => Iterable(seq: _*))
+
+  implicit def seqWriter[T: YW] =
+    viaSeq[Seq[T], T](seq => Seq(seq: _*))
+
+  implicit def indexedSeqWriter[T: YW] =
+    viaSeq[IndexedSeq[T], T](seq => IndexedSeq(seq: _*))
+
+  implicit def linearSeqWriter[T: YW] =
+    viaSeq[LinearSeq[T], T](seq => LinearSeq(seq: _*))
+
+  /**
+   * A YamlWriter construction helper that creates a YamlWriter for an Iterable
+   * type I from a builder function List => I
+   */
+  def viaSeq[I <: Iterable[T], T: YW](f: imm.Seq[T] => I): YW[I] = new YW[I] {
+    def write(iterable: I) = YamlArray(iterable.map(_.toYaml).toVector)
+  }
+}

--- a/src/main/scala/net/jcazevedo/moultingyaml/DefaultYamlProtocol.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/DefaultYamlProtocol.scala
@@ -9,5 +9,7 @@ trait DefaultYamlProtocol
   with CollectionFormats
   with ProductFormats
   with AdditionalFormats
+  with CollectionReaders
+  with CollectionWriters
 
 object DefaultYamlProtocol extends DefaultYamlProtocol

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -10,6 +10,10 @@ package object moultingyaml {
   private[moultingyaml] type YF[A] = YamlFormat[A]
   // format: ON
 
+  private[moultingyaml]type YW[A] = YamlWriter[A]
+
+  private[moultingyaml]type YR[A] = YamlReader[A]
+
   case class DeserializationException(msg: String,
                                       cause: Throwable = null,
                                       fieldNames: List[String] = Nil)

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
@@ -2,7 +2,7 @@ package net.jcazevedo.moultingyaml
 
 import org.specs2.mutable._
 
-class CollectionFormatsSpec extends Specification with CollectionFormats
+class CollectionFormatsSpec extends Specification with CollectionFormats with CollectionWriters
     with BasicFormats {
 
   "The listFormat" should {

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionReadersWritersSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionReadersWritersSpec.scala
@@ -1,0 +1,68 @@
+package net.jcazevedo.moultingyaml
+
+import org.specs2.mutable._
+
+class CollectionReadersWritersSpec extends Specification with CollectionWriters with CollectionReaders
+    with BasicFormats {
+
+  case class MyType(name: String, value: Int)
+
+  implicit val MyTypeReader = new YamlReader[MyType] {
+    def read(yaml: YamlValue) =
+      yaml.asYamlObject.getFields(
+        YamlString("name"), YamlString("value")) match {
+          case Seq(YamlString(name), YamlNumber(value)) =>
+            MyType(name, value.intValue)
+          case _ => deserializationError("Expected fields: 'name' (YAML string) and 'value' (YAML number)")
+        }
+  }
+
+  implicit val MyTypeWriter = new YamlWriter[MyType] {
+    def write(obj: MyType) =
+      YamlObject(
+        YamlString("name") -> YamlString(obj.name),
+        YamlString("value") -> YamlNumber(obj.value))
+  }
+
+  "The listWriter and listReader" should {
+    val list = List(MyType("Bob", 3), MyType("Bill", 5))
+
+    "convert a List of a type with a custom writer to YAML and back correctly" in {
+      list.toYaml.convertTo[List[MyType]] mustEqual list
+    }
+  }
+
+  "The arrayWriter and arrayReader" should {
+    val array = Array(MyType("Bob", 3), MyType("Bill", 5))
+
+    "convert an Array of a type with a custom writer to YAML and back correctly" in {
+      array.toYaml.convertTo[Array[MyType]] mustEqual array
+    }
+  }
+
+  "The setWriter and setReader" should {
+    val set = Set(MyType("Bob", 3), MyType("Bill", 5))
+
+    "convert a Set of a type with a custom writer to YAML and back correctly" in {
+      set.toYaml.convertTo[Set[MyType]] mustEqual set
+    }
+  }
+
+  "The indexedSeqWriter and indexedSeqReader" should {
+    val seq = IndexedSeq(MyType("Bob", 3), MyType("Bill", 5))
+
+    "convert an IndexedSeq of a type with a custom writer to YAML and back correctly" in {
+      seq.toYaml.convertTo[IndexedSeq[MyType]] mustEqual seq
+    }
+  }
+
+  "The mapWriter and mapReader" should {
+    val map = Map(1.1 -> MyType("one", 1), 2.2 -> MyType("two", 2), 3.3 -> MyType("three", 3))
+
+    "convert a Map[Double, MyType] to a YamlObject and back correctly" in {
+      map.toYaml.convertTo[Map[Double, MyType]] mustEqual map
+    }
+
+  }
+
+}


### PR DESCRIPTION
This is for the use case where we have, for example, only a custom writer
for `MyType`, but we want to extent to `List[MyType]`. Basic tests have been written