### PR TITLE
Resolved issue with dropping duplicate keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossScalaVersions := Seq("2.12.0", "2.11.8", "2.10.6")
 libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time"   % "2.14.0",
   "org.scala-lang"          % "scala-reflect" % scalaVersion.value,
-  "org.yaml"                % "snakeyaml"     % "1.17",
+  "org.yaml"                % "snakeyaml"     % "1.21",
   "org.specs2"             %% "specs2-core"   % "3.8.6"  % "test")
 
 scalacOptions ++= Seq(

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -1,7 +1,7 @@
 package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
  * The general type of a YAML AST node.

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -1,7 +1,7 @@
 package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 /**
  * The general type of a YAML AST node.

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -1,6 +1,7 @@
 package net.jcazevedo
 
 import com.github.nscala_time.time.Imports._
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import scala.collection.JavaConverters._
 
@@ -59,11 +60,14 @@ package object moultingyaml {
     def toYaml(implicit writer: YamlWriter[A]): YamlValue = writer.write(any)
   }
 
-  implicit class PimpedString(val string: String) extends AnyVal {
+  implicit class PimpedString(val string: String) {
+    private val loaderOptions = new LoaderOptions
+    loaderOptions.setAllowDuplicateKeys(false)
+
     def parseYaml: YamlValue =
-      convertToYamlValue(new Yaml().load(string))
+      convertToYamlValue(new Yaml(loaderOptions).load(string))
 
     def parseYamls: Seq[YamlValue] =
-      new Yaml().loadAll(string).asScala.map(convertToYamlValue).toSeq
+      new Yaml(loaderOptions).loadAll(string).asScala.map(convertToYamlValue).toSeq
   }
 }

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -61,13 +61,22 @@ package object moultingyaml {
   }
 
   implicit class PimpedString(val string: String) {
-    private val loaderOptions = new LoaderOptions
-    loaderOptions.setAllowDuplicateKeys(false)
+    private def loaderOptions(allowDuplicateKeys: Boolean) = {
+      val loader = new LoaderOptions
+      loader.setAllowDuplicateKeys(allowDuplicateKeys)
+      loader
+    }
 
     def parseYaml: YamlValue =
-      convertToYamlValue(new Yaml(loaderOptions).load(string))
+      convertToYamlValue(new Yaml().load(string))
 
     def parseYamls: Seq[YamlValue] =
-      new Yaml(loaderOptions).loadAll(string).asScala.map(convertToYamlValue).toSeq
+      new Yaml().loadAll(string).asScala.map(convertToYamlValue).toSeq
+
+    def parseYaml(allowDuplicateKeys: Boolean): YamlValue =
+      convertToYamlValue(new Yaml(loaderOptions(allowDuplicateKeys)).load(string))
+
+    def parseYamls(allowDuplicateKeys: Boolean): Seq[YamlValue] =
+      new Yaml(loaderOptions(allowDuplicateKeys)).loadAll(string).asScala.map(convertToYamlValue).toSeq
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
@@ -1,6 +1,7 @@
 package net.jcazevedo.moultingyaml
 
 import org.specs2.mutable._
+import org.yaml.snakeyaml.constructor.DuplicateKeyException
 
 class CollectionFormatsSpec extends Specification with CollectionFormats
     with BasicFormats {
@@ -57,6 +58,14 @@ class CollectionFormatsSpec extends Specification with CollectionFormats
 
     "be able to convert a YamlObject to a Map[Double, Int]" in {
       yaml.convertTo[Map[Double, Int]] mustEqual map
+    }
+
+    "parsing a Yaml map with duplicate keys should throw a DuplicateKeyException" in {
+      val yaml = """hr:  65    # Home runs
+                   |avg: 0.278 # Batting average
+                   |hr:  99    # Duplicate
+                   |rbi: 147   # Runs Batted In""".stripMargin
+      yaml.parseYaml must throwAn[DuplicateKeyException]
     }
   }
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
@@ -65,7 +65,7 @@ class CollectionFormatsSpec extends Specification with CollectionFormats
                    |avg: 0.278 # Batting average
                    |hr:  99    # Duplicate
                    |rbi: 147   # Runs Batted In""".stripMargin
-      yaml.parseYaml must throwAn[DuplicateKeyException]
+      yaml.parseYaml(allowDuplicateKeys = false) must throwAn[DuplicateKeyException]
     }
   }
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/RoundTripSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/RoundTripSpec.scala
@@ -13,9 +13,12 @@ class RoundTripSpec extends Specification {
     "work in a round trip fashion" in {
       val files = new File(getResourceURL("/examples")).listFiles()
       forall(files) { file =>
-        val yamls = Source.fromFile(file).mkString.parseYamls
+        val yamlfiles = Source.fromFile(file).mkString
+        val yamls = yamlfiles.parseYamls
+        val yamlsDuplicateKeysDisallowed = yamlfiles.parseYamls(allowDuplicateKeys = false)
         forall(yamls) { innerYaml =>
           innerYaml.prettyPrint.parseYaml mustEqual innerYaml
+          innerYaml.prettyPrint.parseYaml(allowDuplicateKeys = false) mustEqual innerYaml
         }
       }
     }


### PR DESCRIPTION
I am currently using moultingyaml and have ran into the issue of duplicate keys being dropped (see https://github.com/jcazevedo/moultingyaml/issues/12 ). The fix mentioned in the issue has been merged into snakeyaml but the change was not merged into moultingyaml.

@rbuckland has made a fix on his fork -
https://github.com/rbuckland/moultingyaml/blob/master/src/main/scala/net/jcazevedo/moultingyaml/package.scala

In this pull request, I have gone for a simpler option where I have simply set the parser to fail on duplicate keys. I can't think of a situation where you wouldn't want to fail on duplicate keys. Having said that, I think it it would be better to allow users to configure the behaviour they want.

Edit: I have come up with a solution that maintains backwards compatibility but gives users the ability to customise the parsing behaviour -
```
  implicit class PimpedString(val string: String) extends AnyVal {
    private def loaderOptions(allowDuplicateKeys: Boolean) = {
      val loader = new LoaderOptions
      loader.setAllowDuplicateKeys(allowDuplicateKeys)
      loader
    }

    def parseYaml: YamlValue =
      convertToYamlValue(new Yaml().load(string))

    def parseYamls: Seq[YamlValue] =
      new Yaml().loadAll(string).asScala.map(convertToYamlValue).toSeq

    def parseYaml(allowDuplicateKeys: Boolean): YamlValue =
      convertToYamlValue(new Yaml(loaderOptions(allowDuplicateKeys)).load(string))

    def parseYamls(allowDuplicateKeys: Boolean): Seq[YamlValue] =
      new Yaml(loaderOptions(allowDuplicateKeys)).loadAll(string).asScala.map(convertToYamlValue).toSeq
  }
}
```  