### PR TITLE
support scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,18 @@ scala:
   - 2.13.0
   - 2.12.8
   - 2.11.12
+  - 2.10.7
 
 jdk:
   - oraclejdk8
 script: |
-  if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then
+  if [[ "$TRAVIS_SCALA_VERSION" == 2.13.* ]]; then
     sbt ++$TRAVIS_SCALA_VERSION clean coverage test
   else
     sbt ++$TRAVIS_SCALA_VERSION clean test
   fi
 after_success: |
-  if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then
+  if [[ "$TRAVIS_SCALA_VERSION" == 2.13.* ]]; then
     sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
   fi
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
   - 2.13.0
-  - 2.12.0
-  - 2.11.8
+  - 2.12.8
+  - 2.11.12
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: scala
 scala:
+  - 2.13.0
   - 2.12.0
   - 2.11.8
-  - 2.10.6
+
 jdk:
   - oraclejdk8
 script: |
@@ -14,7 +15,7 @@ script: |
 after_success: |
   if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then
     sbt ++$TRAVIS_SCALA_VERSION coverageReport coverageAggregate coveralls
-  fi  
+  fi
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ version := "0.4.1"
 
 scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.13.0", "2.12.0", "2.11.8")
+crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12")
 
 libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time"   % "2.22.0",

--- a/build.sbt
+++ b/build.sbt
@@ -4,17 +4,17 @@ name := "moultingyaml"
 
 organization := "net.jcazevedo"
 
-version := "0.4.1"
+version := "0.4.1-SNAPSHOT"
 
 scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12")
+crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12", "2.10.7")
 
 libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time"   % "2.22.0",
   "org.scala-lang"          % "scala-reflect" % scalaVersion.value,
   "org.yaml"                % "snakeyaml"     % "1.24",
-  "org.specs2"             %% "specs2-core"   % "4.5.1"  % "test")
+  "org.scalatest"          %% "scalatest"     % "3.0.8"  % "test")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ scalacOptions ++= Seq(
     case _ => Seq()
    })
 
-scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Ywarn-unused:imports"))
+scalacOptions in (Compile, console) ~= (_ filterNot (Set("-Ywarn-unused:imports", "-Ywarn-unused-import").contains))
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
 scalariformSettings

--- a/build.sbt
+++ b/build.sbt
@@ -6,15 +6,15 @@ organization := "net.jcazevedo"
 
 version := "0.4.1-SNAPSHOT"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.12.0", "2.11.8", "2.10.6")
+crossScalaVersions := Seq("2.13.0", "2.12.0", "2.11.8")
 
 libraryDependencies ++= Seq(
-  "com.github.nscala-time" %% "nscala-time"   % "2.14.0",
+  "com.github.nscala-time" %% "nscala-time"   % "2.22.0",
   "org.scala-lang"          % "scala-reflect" % scalaVersion.value,
-  "org.yaml"                % "snakeyaml"     % "1.17",
-  "org.specs2"             %% "specs2-core"   % "3.8.6"  % "test")
+  "org.yaml"                % "snakeyaml"     % "1.24",
+  "org.specs2"             %% "specs2-core"   % "4.5.1"  % "test")
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -22,11 +22,12 @@ scalacOptions ++= Seq(
   "-feature",
   "-language:implicitConversions") ++
   (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, major)) if major >= 13 => Seq("-Ywarn-unused:imports")
     case Some((2, major)) if major >= 11 => Seq("-Ywarn-unused-import")
     case _ => Seq()
    })
 
-scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Ywarn-unused-import"))
+scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Ywarn-unused:imports"))
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
 scalariformSettings

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "moultingyaml"
 
 organization := "net.jcazevedo"
 
-version := "0.4.1-SNAPSHOT"
+version := "0.4.1"
 
 scalaVersion := "2.13.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.4.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
-
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
+addSbtPlugin("org.scoverage"    % "sbt-scoverage"   % "1.6.0")
+addSbtPlugin("org.scoverage"    % "sbt-coveralls"   % "1.2.7")

--- a/src/main/scala/net/jcazevedo/moultingyaml/CollectionFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/CollectionFormats.scala
@@ -13,8 +13,7 @@ trait CollectionFormats {
   implicit def listFormat[A: YF] = new YF[List[A]] {
     def write(list: List[A]) = YamlArray(list.map(_.toYaml).toVector)
     def read(value: YamlValue): List[A] = value match {
-      case YamlArray(elements) =>
-        elements.map(_.convertTo[A])(collection.breakOut)
+      case YamlArray(elements) => elements.map(_.convertTo[A]).toList
       case x =>
         deserializationError("Expected List as YamlArray, but got " + x)
     }

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -1,7 +1,7 @@
 package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
  * The general type of a YAML AST node.
@@ -31,13 +31,13 @@ case class YamlObject(fields: Map[YamlValue, YamlValue]) extends YamlValue {
   override def asYamlObject(errorMsg: String) = this
 
   def getFields(fieldKeys: YamlValue*): Seq[YamlValue] =
-    fieldKeys.flatMap(fields.get)(collection.breakOut)
+    fieldKeys.flatMap(fields.get).toSeq
 
   private[moultingyaml] lazy val snakeYamlObject: Object = {
-    mapAsJavaMap(fields.map {
+    fields.map {
       case (k, v) =>
         k.snakeYamlObject -> v.snakeYamlObject
-    })
+    }.asJava
   }
 }
 
@@ -50,7 +50,7 @@ object YamlObject {
  */
 case class YamlArray(elements: Vector[YamlValue]) extends YamlValue {
   private[moultingyaml] lazy val snakeYamlObject: Object = {
-    seqAsJavaList(elements.map(_.snakeYamlObject))
+    elements.map(_.snakeYamlObject).asJava
   }
 }
 
@@ -63,7 +63,7 @@ object YamlArray {
  */
 case class YamlSet(set: Set[YamlValue]) extends YamlValue {
   private[moultingyaml] lazy val snakeYamlObject: Object = {
-    setAsJavaSet(set.map(_.snakeYamlObject))
+    set.map(_.snakeYamlObject).asJava
   }
 }
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/AdditionalFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/AdditionalFormatsSpec.scala
@@ -1,8 +1,8 @@
 package net.jcazevedo.moultingyaml
 
-import org.specs2.mutable._
+import org.scalatest.{ FlatSpec, Matchers }
 
-class AdditionalFormatsSpec extends Specification {
+class AdditionalFormatsSpec extends FlatSpec with Matchers {
 
   case class Container[A](inner: Option[A])
 
@@ -28,7 +28,7 @@ class AdditionalFormatsSpec extends Specification {
     }
   }
 
-  "A lifted YamlReader" should {
+  {
     val obj = Container(Some(Container(Some(List(1, 2, 3)))))
     val yaml =
       """content:
@@ -40,16 +40,18 @@ class AdditionalFormatsSpec extends Specification {
 
     import ReaderProtocol._
 
-    "properly read a Container[Container[List[Int]]] from YAML" in {
-      yaml.parseYaml.convertTo[Container[Container[List[Int]]]] mustEqual obj
+    "A lifted YamlReader" should "properly read a Container[Container[List[Int]]] from YAML" in {
+      yaml.parseYaml.convertTo[Container[Container[List[Int]]]] should ===(obj)
     }
 
-    "throw a DeserializationException if trying to write with it" in {
-      obj.toYaml must throwAn[UnsupportedOperationException]
+    it should "throw a DeserializationException if trying to write with it" in {
+      a[UnsupportedOperationException] should be thrownBy {
+        obj.toYaml
+      }
     }
   }
 
-  "A lifted YamlWriter" should {
+  {
     val obj = Container(Some(Container(Some(List(1, 2, 3)))))
     val yaml =
       """content:
@@ -61,25 +63,25 @@ class AdditionalFormatsSpec extends Specification {
 
     import WriterProtocol._
 
-    "properly write a Container[Container[List[Int]]] to YAML" in {
-      obj.toYaml.prettyPrint mustEqual yaml
+    "A lifted YamlWriter" should "properly write a Container[Container[List[Int]]] to YAML" in {
+      obj.toYaml.prettyPrint should ===(yaml)
     }
 
-    "throw a DeserializationException if trying to read with it" in {
-      yaml.parseYaml.convertTo[Container[Container[List[Int]]]] must
-        throwAn[UnsupportedOperationException]
+    it should "throw a DeserializationException if trying to read with it" in {
+      a[UnsupportedOperationException] should be thrownBy {
+        yaml.parseYaml.convertTo[Container[Container[List[Int]]]]
+      }
     }
   }
 
-  case class Foo(id: Long, name: String, foos: Option[List[Foo]] = None)
+  {
+    case class Foo(id: Long, name: String, foos: Option[List[Foo]] = None)
 
-  object FooProtocol extends DefaultYamlProtocol {
-    implicit val fooProtocol: YamlFormat[Foo] = lazyFormat(yamlFormat3(Foo))
-  }
+    object FooProtocol extends DefaultYamlProtocol {
+      implicit val fooProtocol: YamlFormat[Foo] = lazyFormat(yamlFormat3(Foo))
+    }
 
-  "The lazyFormat wrapper" should {
-
-    "enable recursive format definitions" in {
+    "The lazyFormat wrapper" should "enable recursive format definitions" in {
       val obj =
         Foo(1, "a", Some(List(
           Foo(2, "b", Some(List(
@@ -87,19 +89,19 @@ class AdditionalFormatsSpec extends Specification {
           Foo(4, "d"))))
 
       val yaml = """id: 1
-                   |name: a
-                   |foos:
-                   |- id: 2
-                   |  name: b
-                   |  foos:
-                   |  - id: 3
-                   |    name: c
-                   |- id: 4
-                   |  name: d
-                   |""".stripMargin
+                     |name: a
+                     |foos:
+                     |- id: 2
+                     |  name: b
+                     |  foos:
+                     |  - id: 3
+                     |    name: c
+                     |- id: 4
+                     |  name: d
+                     |""".stripMargin
 
       import FooProtocol._
-      obj.toYaml.prettyPrint mustEqual yaml
+      obj.toYaml.prettyPrint should ===(yaml)
     }
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/AdditionalFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/AdditionalFormatsSpec.scala
@@ -1,8 +1,9 @@
 package net.jcazevedo.moultingyaml
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
 
-class AdditionalFormatsSpec extends FlatSpec with Matchers {
+class AdditionalFormatsSpec extends FlatSpec {
 
   case class Container[A](inner: Option[A])
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
@@ -199,11 +199,11 @@ class BasicFormatsSpec extends Specification with BasicFormats {
   "The SymbolYamlFormat" should {
 
     "convert a Symbol to a YamlString" in {
-      'Hello.toYaml mustEqual YamlString("Hello")
+      Symbol("Hello").toYaml mustEqual YamlString("Hello")
     }
 
     "convert a YamlString to a Symbol" in {
-      YamlString("Hello").convertTo[Symbol] mustEqual 'Hello
+      YamlString("Hello").convertTo[Symbol] mustEqual Symbol("Hello")
     }
   }
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
@@ -1,221 +1,176 @@
 package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
-import org.specs2.mutable._
+import org.scalatest.{ FlatSpec, Matchers }
 
-class BasicFormatsSpec extends Specification with BasicFormats {
+class BasicFormatsSpec extends FlatSpec with Matchers with BasicFormats {
 
-  "The IntYamlFormat" should {
-
-    "convert an Int to a YamlNumber" in {
-      42.toYaml mustEqual YamlNumber(42)
-    }
-
-    "convert a YamlNumber to an Int" in {
-      YamlNumber(42).convertTo[Int] mustEqual 42
-    }
+  "The IntYamlFormat" should "convert an Int to a YamlNumber" in {
+    42.toYaml should ===(YamlNumber(42))
   }
 
-  "The LongYamlFormat" should {
-
-    "convert a Long to a YamlNumber" in {
-      7563661897011259335L.toYaml mustEqual YamlNumber(7563661897011259335L)
-    }
-
-    "convert a YamlNumber to a Long" in {
-      YamlNumber(7563661897011259335L).convertTo[Long] mustEqual
-        7563661897011259335L
-    }
+  it should "convert a YamlNumber to an Int" in {
+    YamlNumber(42).convertTo[Int] should ===(42)
   }
 
-  "The FloatYamlFormat" should {
-
-    "convert a Float to a YamlNumber" in {
-      4.2f.toYaml mustEqual YamlNumber(4.2f)
-    }
-
-    "convert a Float.NaN to a YamlNumber" in {
-      Float.NaN.toYaml mustEqual YamlNaN
-    }
-
-    "convert a Float.PositiveInfinity to a YamlNumber" in {
-      Float.PositiveInfinity.toYaml mustEqual YamlNumber(Float.PositiveInfinity)
-    }
-
-    "convert a Float.NegativeInfinity to a YamlNumber" in {
-      Float.PositiveInfinity.toYaml mustEqual YamlNumber(Float.PositiveInfinity)
-    }
-
-    "convert a YamlNumber to a Float" in {
-      YamlNumber(4.2f).convertTo[Float] mustEqual 4.2f
-    }
-
-    "convert a YamlNull to a Float" in {
-      YamlNull.convertTo[Float].isNaN mustEqual Float.NaN.isNaN
-    }
-
-    "convert a YamlPositiveInf to a Float" in {
-      YamlPositiveInf.convertTo[Float] mustEqual Float.PositiveInfinity
-    }
-
-    "convert a YamlNegativeInf to a Float" in {
-      YamlNegativeInf.convertTo[Float] mustEqual Float.NegativeInfinity
-    }
+  "The LongYamlFormat" should "convert a Long to a YamlNumber" in {
+    7563661897011259335L.toYaml should ===(YamlNumber(7563661897011259335L))
   }
 
-  "The DoubleYamlFormat" should {
-
-    "convert a Double to a YamlNumber" in {
-      4.2.toYaml mustEqual YamlNumber(4.2)
-    }
-
-    "convert a Double.NaN to a YamlNumber" in {
-      Double.NaN.toYaml mustEqual YamlNaN
-    }
-
-    "convert a Double.PositiveInfinity to a YamlNumber" in {
-      Double.PositiveInfinity.toYaml mustEqual
-        YamlNumber(Double.PositiveInfinity)
-    }
-
-    "convert a Double.NegativeInfinity to a YamlNumber" in {
-      Double.NegativeInfinity.toYaml mustEqual
-        YamlNumber(Double.NegativeInfinity)
-    }
-
-    "convert a YamlNumber to a Double" in {
-      YamlNumber(4.2).convertTo[Double] mustEqual 4.2
-    }
-
-    "convert a YamlNull to a Double" in {
-      YamlNull.convertTo[Double].isNaN mustEqual Double.NaN.isNaN
-    }
-
-    "convert a YamlPositiveInf to a Double" in {
-      YamlPositiveInf.convertTo[Double] mustEqual Double.PositiveInfinity
-    }
-
-    "convert a YamlNegativeInf to a Double" in {
-      YamlNegativeInf.convertTo[Double] mustEqual Double.NegativeInfinity
-    }
+  it should "convert a YamlNumber to a Long" in {
+    YamlNumber(7563661897011259335L).convertTo[Long] should ===(7563661897011259335L)
   }
 
-  "The ByteYamlFormat" should {
-
-    "convert a Byte to a YamlNumber" in {
-      42.asInstanceOf[Byte].toYaml mustEqual YamlNumber(42)
-    }
-
-    "convert a YamlNumber to a Byte" in {
-      YamlNumber(42).convertTo[Byte] mustEqual 42
-    }
+  "The FloatYamlFormat" should "convert a Float to a YamlNumber" in {
+    4.2f.toYaml should ===(YamlNumber(4.2f))
   }
 
-  "The ShortYamlFormat" should {
-
-    "convert a Short to a YamlNumber" in {
-      42.asInstanceOf[Short].toYaml mustEqual YamlNumber(42)
-    }
-
-    "convert a YamlNumber to a Short" in {
-      YamlNumber(42).convertTo[Short] mustEqual 42
-    }
+  it should "convert a Float.NaN to a YamlNumber" in {
+    Float.NaN.toYaml should ===(YamlNaN)
   }
 
-  "The BigDecimalYamlFormat" should {
-
-    "convert a BigDecimal to a YamlNumber" in {
-      BigDecimal(42).toYaml mustEqual YamlNumber(42)
-    }
-
-    "convert a YamlNumber to a BigDecimal" in {
-      YamlNumber(42).convertTo[BigDecimal] mustEqual BigDecimal(42)
-    }
+  it should "convert a Float.PositiveInfinity to a YamlNumber" in {
+    Float.PositiveInfinity.toYaml should ===(YamlNumber(Float.PositiveInfinity))
   }
 
-  "The BigIntYamlFormat" should {
-
-    "convert a BigInt to a YamlNumber" in {
-      BigInt(42).toYaml mustEqual YamlNumber(42)
-    }
-
-    "convert a YamlNumber to a BigInt" in {
-      YamlNumber(42).convertTo[BigInt] mustEqual BigInt(42)
-    }
+  it should "convert a Float.NegativeInfinity to a YamlNumber" in {
+    Float.PositiveInfinity.toYaml should ===(YamlNumber(Float.PositiveInfinity))
   }
 
-  "The UnitYamlFormat" should {
-
-    "convert Unit to a YamlNumber(1)" in {
-      ().toYaml mustEqual YamlNumber(1)
-    }
-
-    "convert a YamlNumber to Unit" in {
-      YamlNumber(1).convertTo[Unit] mustEqual { () }
-    }
+  it should "convert a YamlNumber to a Float" in {
+    YamlNumber(4.2f).convertTo[Float] should ===(4.2f)
   }
 
-  "The BooleanYamlFormat" should {
-
-    "convert true to a YamlTrue" in {
-      true.toYaml mustEqual YamlBoolean(true)
-    }
-
-    "convert false to a YamlFalse" in {
-      false.toYaml mustEqual YamlBoolean(false)
-    }
-
-    "convert a YamlTrue to true" in {
-      YamlBoolean(true).convertTo[Boolean] mustEqual true
-    }
-
-    "convert a YamlFalse to false" in {
-      YamlBoolean(false).convertTo[Boolean] mustEqual false
-    }
+  it should "convert a YamlNull to a Float" in {
+    YamlNull.convertTo[Float].isNaN should ===(Float.NaN.isNaN)
   }
 
-  "The CharYamlFormat" should {
-
-    "convert a Char to a YamlString" in {
-      'c'.toYaml mustEqual YamlString("c")
-    }
-
-    "convert a YamlString to a Char" in {
-      YamlString("c").convertTo[Char] mustEqual 'c'
-    }
+  it should "convert a YamlPositiveInf to a Float" in {
+    YamlPositiveInf.convertTo[Float] should ===(Float.PositiveInfinity)
   }
 
-  "The StringYamlFormat" should {
-
-    "convert a String to a YamlString" in {
-      "Hello".toYaml mustEqual YamlString("Hello")
-    }
-
-    "convert a YamlString to a String" in {
-      YamlString("Hello").convertTo[String] mustEqual "Hello"
-    }
+  it should "convert a YamlNegativeInf to a Float" in {
+    YamlNegativeInf.convertTo[Float] should ===(Float.NegativeInfinity)
   }
 
-  "The SymbolYamlFormat" should {
-
-    "convert a Symbol to a YamlString" in {
-      Symbol("Hello").toYaml mustEqual YamlString("Hello")
-    }
-
-    "convert a YamlString to a Symbol" in {
-      YamlString("Hello").convertTo[Symbol] mustEqual Symbol("Hello")
-    }
+  "The DoubleYamlFormat" should "convert a Double to a YamlNumber" in {
+    4.2.toYaml should ===(YamlNumber(4.2))
   }
 
-  "The DateTimeYamlFormat" should {
+  it should "convert a Double.NaN to a YamlNumber" in {
+    Double.NaN.toYaml should ===(YamlNaN)
+  }
 
-    "convert a DateTime to a YamlDate" in {
-      "2015-07-01".toDateTime.toYaml mustEqual YamlDate("2015-07-01".toDateTime)
-    }
+  it should "convert a Double.PositiveInfinity to a YamlNumber" in {
+    Double.PositiveInfinity.toYaml should ===(YamlNumber(Double.PositiveInfinity))
+  }
 
-    "convert a YamlDate to a DateTime" in {
-      YamlDate("2015-07-01".toDateTime).convertTo[DateTime] mustEqual
-        "2015-07-01".toDateTime
-    }
+  it should "convert a Double.NegativeInfinity to a YamlNumber" in {
+    Double.NegativeInfinity.toYaml should ===(YamlNumber(Double.NegativeInfinity))
+  }
+
+  it should "convert a YamlNumber to a Double" in {
+    YamlNumber(4.2).convertTo[Double] should ===(4.2)
+  }
+
+  it should "convert a YamlNull to a Double" in {
+    YamlNull.convertTo[Double].isNaN should ===(Double.NaN.isNaN)
+  }
+
+  it should "convert a YamlPositiveInf to a Double" in {
+    YamlPositiveInf.convertTo[Double] should ===(Double.PositiveInfinity)
+  }
+
+  it should "convert a YamlNegativeInf to a Double" in {
+    YamlNegativeInf.convertTo[Double] should ===(Double.NegativeInfinity)
+  }
+
+  "The ByteYamlFormat" should "convert a Byte to a YamlNumber" in {
+    42.asInstanceOf[Byte].toYaml should ===(YamlNumber(42))
+  }
+
+  it should "convert a YamlNumber to a Byte" in {
+    YamlNumber(42).convertTo[Byte] should ===(42)
+  }
+
+  "The ShortYamlFormat" should "convert a Short to a YamlNumber" in {
+    42.asInstanceOf[Short].toYaml should ===(YamlNumber(42))
+  }
+
+  it should "convert a YamlNumber to a Short" in {
+    YamlNumber(42).convertTo[Short] should ===(42)
+  }
+
+  "The BigDecimalYamlFormat" should "convert a BigDecimal to a YamlNumber" in {
+    BigDecimal(42).toYaml should ===(YamlNumber(42))
+  }
+
+  it should "convert a YamlNumber to a BigDecimal" in {
+    YamlNumber(42).convertTo[BigDecimal] should ===(BigDecimal(42))
+  }
+
+  "The BigIntYamlFormat" should "convert a BigInt to a YamlNumber" in {
+    BigInt(42).toYaml should ===(YamlNumber(42))
+  }
+
+  it should "convert a YamlNumber to a BigInt" in {
+    YamlNumber(42).convertTo[BigInt] should ===(BigInt(42))
+  }
+
+  "The UnitYamlFormat" should "convert Unit to a YamlNumber(1)" in {
+    ().toYaml should ===(YamlNumber(1))
+  }
+
+  it should "convert a YamlNumber to Unit" in {
+    YamlNumber(1).convertTo[Unit] should ===(())
+  }
+
+  "The BooleanYamlFormat" should "convert true to a YamlTrue" in {
+    true.toYaml should ===(YamlBoolean(true))
+  }
+
+  it should "convert false to a YamlFalse" in {
+    false.toYaml should ===(YamlBoolean(false))
+  }
+
+  it should "convert a YamlTrue to true" in {
+    YamlBoolean(true).convertTo[Boolean] should ===(true)
+  }
+
+  it should "convert a YamlFalse to false" in {
+    YamlBoolean(false).convertTo[Boolean] should ===(false)
+  }
+
+  "The CharYamlFormat" should "convert a Char to a YamlString" in {
+    'c'.toYaml should ===(YamlString("c"))
+  }
+
+  it should "convert a YamlString to a Char" in {
+    YamlString("c").convertTo[Char] should ===('c')
+  }
+
+  "The StringYamlFormat" should "convert a String to a YamlString" in {
+    "Hello".toYaml should ===(YamlString("Hello"))
+  }
+
+  it should "convert a YamlString to a String" in {
+    YamlString("Hello").convertTo[String] should ===("Hello")
+  }
+
+  "The SymbolYamlFormat" should "convert a Symbol to a YamlString" in {
+    Symbol("Hello").toYaml should ===(YamlString("Hello"))
+  }
+
+  it should "convert a YamlString to a Symbol" in {
+    println(YamlString("Hello").convertTo[Symbol])
+    YamlString("Hello").convertTo[Symbol] should equal(Symbol("Hello"))
+  }
+
+  "The DateTimeYamlFormat" should "convert a DateTime to a YamlDate" in {
+    "2015-07-01".toDateTime.toYaml should ===(YamlDate("2015-07-01".toDateTime))
+  }
+
+  it should "convert a YamlDate to a DateTime" in {
+    YamlDate("2015-07-01".toDateTime).convertTo[DateTime] should ===("2015-07-01".toDateTime)
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/BasicFormatsSpec.scala
@@ -1,9 +1,10 @@
 package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
 
-class BasicFormatsSpec extends FlatSpec with Matchers with BasicFormats {
+class BasicFormatsSpec extends FlatSpec with BasicFormats {
 
   "The IntYamlFormat" should "convert an Int to a YamlNumber" in {
     42.toYaml should ===(YamlNumber(42))

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
@@ -1,75 +1,75 @@
 package net.jcazevedo.moultingyaml
 
-import org.specs2.mutable._
+import org.scalatest.{ FlatSpec, Matchers }
 
-class CollectionFormatsSpec extends Specification with CollectionFormats
+class CollectionFormatsSpec extends FlatSpec with Matchers with CollectionFormats
     with BasicFormats {
 
-  "The listFormat" should {
+  {
     val list = List(1, 2, 3)
     val yaml = YamlArray(YamlNumber(1), YamlNumber(2), YamlNumber(3))
 
-    "convert a List[Int] to a YamlArray of YamlNumbers" in {
-      list.toYaml mustEqual yaml
+    "The listFormat" should "convert a List[Int] to a YamlArray of YamlNumbers" in {
+      list.toYaml should ===(yaml)
     }
 
-    "convert a YamlArray of YamlNumbers to a List[Int]" in {
-      yaml.convertTo[List[Int]] mustEqual list
+    it should "convert a YamlArray of YamlNumbers to a List[Int]" in {
+      yaml.convertTo[List[Int]] should ===(list)
     }
   }
 
-  "The arrayFormat" should {
+  {
     val array = Array(1, 2, 3)
     val yaml = YamlArray(YamlNumber(1), YamlNumber(2), YamlNumber(3))
 
-    "convert an Array[Int] to a YamlArray of YamlNumbers" in {
-      array.toYaml mustEqual yaml
+    "The arrayFormat" should "convert an Array[Int] to a YamlArray of YamlNumbers" in {
+      array.toYaml should ===(yaml)
     }
 
-    "convert a YamlArray of YamlNumbers to an Array[Int]" in {
-      yaml.convertTo[Array[Int]] mustEqual array
+    it should "convert a YamlArray of YamlNumbers to an Array[Int]" in {
+      yaml.convertTo[Array[Int]] should ===(array)
     }
   }
 
-  "The setFormat" should {
+  {
     val set = Set(1, 2, 3)
     val yaml = YamlSet(YamlNumber(1), YamlNumber(2), YamlNumber(3))
 
-    "convert a Set[Int] to a YamlSet of YamlNumbers" in {
-      set.toYaml mustEqual yaml
+    "The setFormat" should "convert a Set[Int] to a YamlSet of YamlNumbers" in {
+      set.toYaml should ===(yaml)
     }
 
-    "convert a YamlSet of YamlNumbers to a Set[Int]" in {
-      yaml.convertTo[Set[Int]] mustEqual set
+    it should "convert a YamlSet of YamlNumbers to a Set[Int]" in {
+      yaml.convertTo[Set[Int]] should ===(set)
     }
   }
 
-  "The mapFormat" should {
+  {
     val map = Map(1.1 -> 1, 2.2 -> 2, 3.3 -> 3)
     val yaml = YamlObject(
       YamlNumber(1.1) -> YamlNumber(1),
       YamlNumber(2.2) -> YamlNumber(2),
       YamlNumber(3.3) -> YamlNumber(3))
 
-    "convert a Map[Double, Int] to a YamlObject" in {
-      map.toYaml mustEqual yaml
+    "The mapFormat" should "convert a Map[Double, Int] to a YamlObject" in {
+      map.toYaml should ===(yaml)
     }
 
-    "be able to convert a YamlObject to a Map[Double, Int]" in {
-      yaml.convertTo[Map[Double, Int]] mustEqual map
+    it should "be able to convert a YamlObject to a Map[Double, Int]" in {
+      yaml.convertTo[Map[Double, Int]] should ===(map)
     }
   }
 
-  "The indexedSeqFormat" should {
+  {
     val seq = collection.IndexedSeq(1, 2, 3)
     val yaml = YamlArray(YamlNumber(1), YamlNumber(2), YamlNumber(3))
 
-    "convert an IndexedSeq[Int] to a YamlArray of YamlNumbers" in {
-      seq.toYaml mustEqual yaml
+    "The indexedSeqFormat" should "convert an IndexedSeq[Int] to a YamlArray of YamlNumbers" in {
+      seq.toYaml should ===(yaml)
     }
 
-    "convert a YamlArray of YamlNumbers to an IndexedSeq[Int]" in {
-      yaml.convertTo[collection.IndexedSeq[Int]] mustEqual seq
+    it should "convert a YamlArray of YamlNumbers to an IndexedSeq[Int]" in {
+      yaml.convertTo[collection.IndexedSeq[Int]] should ===(seq)
     }
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
@@ -1,8 +1,9 @@
 package net.jcazevedo.moultingyaml
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
 
-class CollectionFormatsSpec extends FlatSpec with Matchers with CollectionFormats
+class CollectionFormatsSpec extends FlatSpec with CollectionFormats
     with BasicFormats {
 
   {

--- a/src/test/scala/net/jcazevedo/moultingyaml/CustomFormatSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CustomFormatSpec.scala
@@ -1,8 +1,9 @@
 package net.jcazevedo.moultingyaml
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
 
-class CustomFormatSpec extends FlatSpec with Matchers with DefaultYamlProtocol {
+class CustomFormatSpec extends FlatSpec with DefaultYamlProtocol {
   case class MyType(name: String, value: Int)
 
   implicit val MyTypeProtocol = new YamlFormat[MyType] {

--- a/src/test/scala/net/jcazevedo/moultingyaml/CustomFormatSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CustomFormatSpec.scala
@@ -1,8 +1,8 @@
 package net.jcazevedo.moultingyaml
 
-import org.specs2.mutable.Specification
+import org.scalatest.{ FlatSpec, Matchers }
 
-class CustomFormatSpec extends Specification with DefaultYamlProtocol {
+class CustomFormatSpec extends FlatSpec with Matchers with DefaultYamlProtocol {
   case class MyType(name: String, value: Int)
 
   implicit val MyTypeProtocol = new YamlFormat[MyType] {
@@ -20,16 +20,16 @@ class CustomFormatSpec extends Specification with DefaultYamlProtocol {
         YamlString("value") -> YamlNumber(obj.value))
   }
 
-  "A custom YamlFormat built with 'asYamlObject'" should {
+  {
     val value = MyType("bob", 42)
 
-    "correctly deserialize valid YAML content" in {
+    "A custom YamlFormat built with 'asYamlObject'" should "correctly deserialize valid YAML content" in {
       """name: bob
-        |value: 42""".stripMargin.parseYaml.convertTo[MyType] mustEqual value
+          |value: 42""".stripMargin.parseYaml.convertTo[MyType] should ===(value)
     }
 
-    "support full round-trip (de)serialization" in {
-      value.toYaml.convertTo[MyType] mustEqual value
+    it should "support full round-trip (de)serialization" in {
+      value.toYaml.convertTo[MyType] should ===(value)
     }
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
@@ -1,8 +1,11 @@
 package net.jcazevedo.moultingyaml
 
-import org.scalatest.{ FlatSpec, Inside, Inspectors, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import org.scalatest.Inside._
+import org.scalatest.Inspectors._
 
-class ProductFormatsSpec extends FlatSpec with Matchers with Inside with Inspectors {
+class ProductFormatsSpec extends FlatSpec {
 
   case class Test0()
   case class Test2(a: Int, b: Option[Double])

--- a/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
@@ -197,7 +197,11 @@ class ProductFormatsSpec extends Specification {
         |""".stripMargin
 
     "produce the correct YAML" in {
-      TestMangled(42, "Karl", true, 26, 1.0f).toYaml.prettyPrint === yaml
+      val result = TestMangled(42, "Karl", true, 26, 1.0f).toYaml.prettyPrint
+
+      yaml.split("\n").forall { line =>
+        result must contain(line)
+      }
     }
 
     "convert a YamlObject to the respective case class instance" in {

--- a/src/test/scala/net/jcazevedo/moultingyaml/RoundTripSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/RoundTripSpec.scala
@@ -3,10 +3,13 @@ package net.jcazevedo.moultingyaml
 import java.io.File
 import java.net.URLDecoder
 
-import org.scalatest.{ FlatSpec, Inspectors, Matchers }
 import scala.io.Source
 
-class RoundTripSpec extends FlatSpec with Matchers with Inspectors {
+import org.scalatest.FlatSpec
+import org.scalatest.Inspectors._
+import org.scalatest.Matchers._
+
+class RoundTripSpec extends FlatSpec {
   def getResourceURL(resource: String): String =
     URLDecoder.decode(getClass.getResource(resource).getFile, "UTF-8")
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/RoundTripSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/RoundTripSpec.scala
@@ -2,21 +2,20 @@ package net.jcazevedo.moultingyaml
 
 import java.io.File
 import java.net.URLDecoder
-import org.specs2.mutable.Specification
+
+import org.scalatest.{ FlatSpec, Inspectors, Matchers }
 import scala.io.Source
 
-class RoundTripSpec extends Specification {
+class RoundTripSpec extends FlatSpec with Matchers with Inspectors {
   def getResourceURL(resource: String): String =
     URLDecoder.decode(getClass.getResource(resource).getFile, "UTF-8")
 
-  "The parsing of YAMLs" should {
-    "work in a round trip fashion" in {
-      val files = new File(getResourceURL("/examples")).listFiles()
-      forall(files) { file =>
-        val yamls = Source.fromFile(file).mkString.parseYamls
-        forall(yamls) { innerYaml =>
-          innerYaml.prettyPrint.parseYaml mustEqual innerYaml
-        }
+  "The parsing of YAMLs" should "work in a round trip fashion" in {
+    val files = new File(getResourceURL("/examples")).listFiles()
+    forAll(files) { file =>
+      val yamls = Source.fromFile(file).mkString.parseYamls
+      forAll(yamls) { innerYaml =>
+        innerYaml.prettyPrint.parseYaml should ===(innerYaml)
       }
     }
   }

--- a/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
@@ -1,137 +1,132 @@
 package net.jcazevedo.moultingyaml
 
-import org.specs2.mutable._
+import org.scalatest.{ FlatSpec, Matchers }
 
-class StandardFormatsSpec extends Specification with StandardFormats
+class StandardFormatsSpec extends FlatSpec with Matchers with StandardFormats
     with BasicFormats {
 
-  "The optionFormat" should {
+  "The optionFormat" should "convert None to YamlNull" in {
+    None.asInstanceOf[Option[Int]].toYaml should ===(YamlNull)
+  }
 
-    "convert None to YamlNull" in {
-      None.asInstanceOf[Option[Int]].toYaml mustEqual YamlNull
+  it should "convert YamlNull to None" in {
+    YamlNull.convertTo[Option[Int]] should ===(None)
+  }
+
+  it should "convert Some(Hello) to YamlString(Hello)" in {
+    Some("Hello").asInstanceOf[Option[String]].toYaml should ===(YamlString("Hello"))
+  }
+
+  it should "convert YamlString(Hello) to Some(Hello)" in {
+    YamlString("Hello").convertTo[Option[String]] should ===(Some("Hello"))
+  }
+
+  {
+    val eitherA: Either[Int, String] = Left(42)
+    val eitherB: Either[Int, String] = Right("Hello")
+
+    "The eitherFormat" should "convert the left side of an Either value to a YamlValue" in {
+      eitherA.toYaml should ===(YamlNumber(42))
     }
 
-    "convert YamlNull to None" in {
-      YamlNull.convertTo[Option[Int]] mustEqual None
+    it should "convert the right side of an Either value to a YamlValue" in {
+      eitherB.toYaml should ===(YamlString("Hello"))
     }
 
-    "convert Some(Hello) to YamlString(Hello)" in {
-      Some("Hello").asInstanceOf[Option[String]].toYaml mustEqual
-        YamlString("Hello")
+    it should "convert the left side of an Either value from a YamlValue" in {
+      YamlNumber(42).convertTo[Either[Int, String]] should ===(Left(42))
     }
 
-    "convert YamlString(Hello) to Some(Hello)" in {
-      YamlString("Hello").convertTo[Option[String]] mustEqual Some("Hello")
+    it should "convert the right side of an Either value from a YamlValue" in {
+      YamlString("Hello").convertTo[Either[Int, String]] should ===(Right("Hello"))
+    }
+
+    it should "fail when a YamlValue can be parsed to both sides of an Either" in {
+      a[DeserializationException] should be thrownBy {
+        YamlNumber(42).convertTo[Either[Int, Long]]
+      }
+    }
+
+    it should "fail when a YamlValue cannot be parsed to any side of an Either" in {
+      a[DeserializationException] should be thrownBy {
+        YamlString("Hello").convertTo[Either[Int, Long]]
+      }
     }
   }
 
-  "The eitherFormat" should {
-    val a: Either[Int, String] = Left(42)
-    val b: Either[Int, String] = Right("Hello")
-
-    "convert the left side of an Either value to a YamlValue" in {
-      a.toYaml mustEqual YamlNumber(42)
-    }
-
-    "convert the right side of an Either value to a YamlValue" in {
-      b.toYaml mustEqual YamlString("Hello")
-    }
-
-    "convert the left side of an Either value from a YamlValue" in {
-      YamlNumber(42).convertTo[Either[Int, String]] mustEqual Left(42)
-    }
-
-    "convert the right side of an Either value from a YamlValue" in {
-      YamlString("Hello").convertTo[Either[Int, String]] mustEqual
-        Right("Hello")
-    }
-
-    "fail when a YamlValue can be parsed to both sides of an Either" in {
-      YamlNumber(42).convertTo[Either[Int, Long]] must
-        throwA[DeserializationException]
-    }
-
-    "fail when a YamlValue cannot be parsed to any side of an Either" in {
-      YamlString("Hello").convertTo[Either[Int, Long]] must
-        throwA[DeserializationException]
-    }
-  }
-
-  "The tuple2Format" should {
+  {
     val yaml = YamlArray(YamlNumber(42), YamlNumber(4.2))
 
-    "convert (42, 4.2) to a YamlArray" in {
-      (42, 4.2).toYaml mustEqual yaml
+    "The tuple2Format" should "convert (42, 4.2) to a YamlArray" in {
+      (42, 4.2).toYaml should ===(yaml)
     }
 
-    "be able to convert a YamlArray to a (Int, Double)]" in {
-      yaml.convertTo[(Int, Double)] mustEqual (42, 4.2)
+    it should "be able to convert a YamlArray to a (Int, Double)]" in {
+      yaml.convertTo[(Int, Double)] should ===((42, 4.2))
     }
   }
 
-  "The tuple3Format" should {
+  {
     val yaml = YamlArray(YamlNumber(42), YamlNumber(4.2), YamlNumber(3))
 
-    "convert (42, 4.2, 3) to a YamlArray" in {
-      (42, 4.2, 3).toYaml mustEqual yaml
+    "The tuple3Format" should "convert (42, 4.2, 3) to a YamlArray" in {
+      (42, 4.2, 3).toYaml should ===(yaml)
     }
 
-    "be able to convert a YamlArray to a (Int, Double, Int)]" in {
-      yaml.convertTo[(Int, Double, Int)] mustEqual (42, 4.2, 3)
+    it should "be able to convert a YamlArray to a (Int, Double, Int)]" in {
+      yaml.convertTo[(Int, Double, Int)] should ===((42, 4.2, 3))
     }
   }
 
-  "The tuple4Format" should {
+  {
     val yaml = YamlArray(YamlNumber(42), YamlNumber(4.2), YamlNumber(3),
       YamlNumber(4))
 
-    "convert (42, 4.2, 3, 4) to a YamlArray" in {
-      (42, 4.2, 3, 4).toYaml mustEqual yaml
+    "The tuple4Format" should "convert (42, 4.2, 3, 4) to a YamlArray" in {
+      (42, 4.2, 3, 4).toYaml should ===(yaml)
     }
 
-    "be able to convert a YamlArray to a (Int, Double, Int, Int)]" in {
-      yaml.convertTo[(Int, Double, Int, Int)] mustEqual (42, 4.2, 3, 4)
+    it should "be able to convert a YamlArray to a (Int, Double, Int, Int)]" in {
+      yaml.convertTo[(Int, Double, Int, Int)] should ===((42, 4.2, 3, 4))
     }
   }
 
-  "The tuple5Format" should {
+  {
     val yaml = YamlArray(YamlNumber(42), YamlNumber(4.2), YamlNumber(3),
       YamlNumber(4), YamlNumber(5))
 
-    "convert (42, 4.2, 3, 4, 5) to a YamlArray" in {
-      (42, 4.2, 3, 4, 5).toYaml mustEqual yaml
+    "The tuple5Format" should "convert (42, 4.2, 3, 4, 5) to a YamlArray" in {
+      (42, 4.2, 3, 4, 5).toYaml should ===(yaml)
     }
 
-    "be able to convert a YamlArray to a (Int, Double, Int, Int, Int)]" in {
-      yaml.convertTo[(Int, Double, Int, Int, Int)] mustEqual (42, 4.2, 3, 4, 5)
+    it should "be able to convert a YamlArray to a (Int, Double, Int, Int, Int)]" in {
+      yaml.convertTo[(Int, Double, Int, Int, Int)] should ===((42, 4.2, 3, 4, 5))
     }
   }
 
-  "The tuple6Format" should {
+  {
     val yaml = YamlArray(YamlNumber(42), YamlNumber(4.2), YamlNumber(3),
       YamlNumber(4), YamlNumber(5), YamlNumber(6))
 
-    "convert (42, 4.2, 3, 4, 5, 6) to a YamlArray" in {
-      (42, 4.2, 3, 4, 5, 6).toYaml mustEqual yaml
+    "The tuple6Format" should "convert (42, 4.2, 3, 4, 5, 6) to a YamlArray" in {
+      (42, 4.2, 3, 4, 5, 6).toYaml should ===(yaml)
     }
 
-    "be able to convert a YamlArray to a (Int, Double, Int, Int, Int, Int)]" in {
-      yaml.convertTo[(Int, Double, Int, Int, Int, Int)] mustEqual
-        (42, 4.2, 3, 4, 5, 6)
+    it should "be able to convert a YamlArray to a (Int, Double, Int, Int, Int, Int)]" in {
+      yaml.convertTo[(Int, Double, Int, Int, Int, Int)] should ===((42, 4.2, 3, 4, 5, 6))
     }
   }
 
-  "The tuple7Format" should {
+  {
     val yaml = YamlArray(YamlNumber(42), YamlNumber(4.2), YamlNumber(3),
       YamlNumber(4), YamlNumber(5), YamlNumber(6), YamlNumber(7))
 
-    "convert (42, 4.2, 3, 4, 5, 6, 7) to a YamlArray" in {
-      (42, 4.2, 3, 4, 5, 6, 7).toYaml mustEqual yaml
+    "The tuple7Format" should "convert (42, 4.2, 3, 4, 5, 6, 7) to a YamlArray" in {
+      (42, 4.2, 3, 4, 5, 6, 7).toYaml should ===(yaml)
     }
 
-    "be able to convert a YamlArray to a (Int, Double, Int, Int, Int, Int, Int)]" in {
-      yaml.convertTo[(Int, Double, Int, Int, Int, Int, Int)] mustEqual
-        (42, 4.2, 3, 4, 5, 6, 7)
+    it should "be able to convert a YamlArray to a (Int, Double, Int, Int, Int, Int, Int)]" in {
+      yaml.convertTo[(Int, Double, Int, Int, Int, Int, Int)] should ===((42, 4.2, 3, 4, 5, 6, 7))
     }
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
@@ -1,8 +1,9 @@
 package net.jcazevedo.moultingyaml
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
 
-class StandardFormatsSpec extends FlatSpec with Matchers with StandardFormats
+class StandardFormatsSpec extends FlatSpec with StandardFormats
     with BasicFormats {
 
   "The optionFormat" should "convert None to YamlNull" in {

--- a/src/test/scala/net/jcazevedo/moultingyaml/YamlParserSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/YamlParserSpec.scala
@@ -2,282 +2,281 @@ package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
 import java.net.URLDecoder
-import org.specs2.execute.Result
-import org.specs2.mutable._
+
 import scala.io.Source
 import scala.util.{ Failure, Success, Try }
 
-class YamlParserSpec extends Specification {
+import org.scalactic.source.Position
+import org.scalatest.{ FlatSpec, Matchers }
+
+class YamlParserSpec extends FlatSpec with Matchers {
   def getResourceURL(resource: String): String =
     URLDecoder.decode(getClass.getResource(resource).getFile, "UTF-8")
 
-  def withYaml(filename: String)(f: YamlValue => Result): Result = {
-    withYamls(filename) { s => f(s(0)) }
+  def withYaml(filename: String)(testFun: YamlValue => Any)(implicit pos: Position): Unit = {
+    withYamls(filename) { s => testFun(s(0)) }
   }
 
-  def withYamls(filename: String)(f: Seq[YamlValue] => Result): Result = {
+  def withYamls(filename: String)(testFun: Seq[YamlValue] => Any)(implicit pos: Position): Unit = {
     Try(Source.fromFile(getResourceURL(filename)).mkString.parseYamls) match {
-      case Success(yamls) => f(yamls)
+      case Success(yamls) => testFun(yamls)
       case Failure(error) =>
         error.printStackTrace()
-        org.specs2.execute.Failure("Unable to parse YAML")
+        fail("Unable to parse YAML")
     }
   }
 
-  "The provided YAML parser" should {
-    "correctly parse sequences of scalars" in withYaml("/examples/ex1.yaml") { yaml =>
-      yaml mustEqual YamlArray(
-        YamlString("Mark McGwire"),
-        YamlString("Sammy Sosa"),
-        YamlString("Ken Griffey"))
-    }
+  "The provided YAML parser" should "correctly parse sequences of scalars" in withYaml("/examples/ex1.yaml") { yaml =>
+    yaml should ===(YamlArray(
+      YamlString("Mark McGwire"),
+      YamlString("Sammy Sosa"),
+      YamlString("Ken Griffey")))
+  }
 
-    "correctly parse mappings of scalars to scalars" in withYaml("/examples/ex2.yaml") { yaml =>
-      yaml mustEqual YamlObject(
+  it should "correctly parse mappings of scalars to scalars" in withYaml("/examples/ex2.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("hr") -> YamlNumber(65),
+      YamlString("avg") -> YamlNumber(0.278),
+      YamlString("rbi") -> YamlNumber(147)))
+  }
+
+  it should "correctly parse mappings of scalars to sequences" in withYaml("/examples/ex3.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("american") -> YamlArray(
+        YamlString("Boston Red Sox"),
+        YamlString("Detroit Tigers"),
+        YamlString("New York Yankees")),
+      YamlString("national") -> YamlArray(
+        YamlString("New York Mets"),
+        YamlString("Chicago Cubs"),
+        YamlString("Atlanta Braves"))))
+  }
+
+  it should "correctly parse sequences of mappings" in withYaml("/examples/ex4.yaml") { yaml =>
+    yaml should ===(YamlArray(
+      YamlObject(
+        YamlString("name") -> YamlString("Mark McGwire"),
         YamlString("hr") -> YamlNumber(65),
-        YamlString("avg") -> YamlNumber(0.278),
-        YamlString("rbi") -> YamlNumber(147))
-    }
+        YamlString("avg") -> YamlNumber(0.278)),
+      YamlObject(
+        YamlString("name") -> YamlString("Sammy Sosa"),
+        YamlString("hr") -> YamlNumber(63),
+        YamlString("avg") -> YamlNumber(0.288))))
+  }
 
-    "correctly parse mappings of scalars to sequences" in withYaml("/examples/ex3.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("american") -> YamlArray(
-          YamlString("Boston Red Sox"),
-          YamlString("Detroit Tigers"),
-          YamlString("New York Yankees")),
-        YamlString("national") -> YamlArray(
-          YamlString("New York Mets"),
-          YamlString("Chicago Cubs"),
-          YamlString("Atlanta Braves")))
-    }
+  it should "correctly parse sequences of sequences" in withYaml("/examples/ex5.yaml") { yaml =>
+    yaml should ===(YamlArray(
+      YamlArray(
+        YamlString("name"),
+        YamlString("hr"),
+        YamlString("avg")),
+      YamlArray(
+        YamlString("Mark McGwire"),
+        YamlNumber(65),
+        YamlNumber(0.278)),
+      YamlArray(
+        YamlString("Sammy Sosa"),
+        YamlNumber(63),
+        YamlNumber(0.288))))
+  }
 
-    "correctly parse sequences of mappings" in withYaml("/examples/ex4.yaml") { yaml =>
-      yaml mustEqual YamlArray(
-        YamlObject(
-          YamlString("name") -> YamlString("Mark McGwire"),
-          YamlString("hr") -> YamlNumber(65),
-          YamlString("avg") -> YamlNumber(0.278)),
-        YamlObject(
-          YamlString("name") -> YamlString("Sammy Sosa"),
-          YamlString("hr") -> YamlNumber(63),
-          YamlString("avg") -> YamlNumber(0.288)))
-    }
+  it should "correctly parse mappings of mappings" in withYaml("/examples/ex6.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("Mark McGwire") -> YamlObject(
+        YamlString("hr") -> YamlNumber(65),
+        YamlString("avg") -> YamlNumber(0.278)),
+      YamlString("Sammy Sosa") -> YamlObject(
+        YamlString("hr") -> YamlNumber(63),
+        YamlString("avg") -> YamlNumber(0.288))))
+  }
 
-    "correctly parse sequences of sequences" in withYaml("/examples/ex5.yaml") { yaml =>
-      yaml mustEqual YamlArray(
-        YamlArray(
-          YamlString("name"),
-          YamlString("hr"),
-          YamlString("avg")),
+  it should "correctly parse aliased nodes" in withYaml("/examples/ex7.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("hr") ->
         YamlArray(
           YamlString("Mark McGwire"),
-          YamlNumber(65),
-          YamlNumber(0.278)),
+          YamlString("Sammy Sosa")),
+      YamlString("rbi") ->
         YamlArray(
           YamlString("Sammy Sosa"),
-          YamlNumber(63),
-          YamlNumber(0.288)))
-    }
+          YamlString("Ken Griffey"))))
+  }
 
-    "correctly parse mappings of mappings" in withYaml("/examples/ex6.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("Mark McGwire") -> YamlObject(
-          YamlString("hr") -> YamlNumber(65),
-          YamlString("avg") -> YamlNumber(0.278)),
-        YamlString("Sammy Sosa") -> YamlObject(
-          YamlString("hr") -> YamlNumber(63),
-          YamlString("avg") -> YamlNumber(0.288)))
-    }
-
-    "correctly parse aliased nodes" in withYaml("/examples/ex7.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("hr") ->
-          YamlArray(
-            YamlString("Mark McGwire"),
-            YamlString("Sammy Sosa")),
-        YamlString("rbi") ->
-          YamlArray(
-            YamlString("Sammy Sosa"),
-            YamlString("Ken Griffey")))
-    }
-
-    "correctly parse mappings between sequences" in withYaml("/examples/ex8.yaml") { yaml =>
-      yaml mustEqual YamlObject(
+  it should "correctly parse mappings between sequences" in withYaml("/examples/ex8.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlArray(
+        YamlString("Detroit Tigers"),
+        YamlString("Chicago cubs")) ->
         YamlArray(
-          YamlString("Detroit Tigers"),
-          YamlString("Chicago cubs")) ->
-          YamlArray(
-            YamlDate(new DateTime(
-              new DateTime("2001-07-23", DateTimeZone.UTC).getMillis(),
-              DateTimeZone.getDefault()))),
+          YamlDate(new DateTime(
+            new DateTime("2001-07-23", DateTimeZone.UTC).getMillis(),
+            DateTimeZone.getDefault()))),
+      YamlArray(
+        YamlString("New York Yankees"),
+        YamlString("Atlanta Braves")) ->
         YamlArray(
-          YamlString("New York Yankees"),
-          YamlString("Atlanta Braves")) ->
-          YamlArray(
-            YamlDate(new DateTime(
-              new DateTime("2001-07-02", DateTimeZone.UTC).getMillis(),
-              DateTimeZone.getDefault())),
-            YamlDate(new DateTime(
-              new DateTime("2001-08-12", DateTimeZone.UTC).getMillis(),
-              DateTimeZone.getDefault())),
-            YamlDate(new DateTime(
-              new DateTime("2001-08-14", DateTimeZone.UTC).getMillis(),
-              DateTimeZone.getDefault()))))
-    }
+          YamlDate(new DateTime(
+            new DateTime("2001-07-02", DateTimeZone.UTC).getMillis(),
+            DateTimeZone.getDefault())),
+          YamlDate(new DateTime(
+            new DateTime("2001-08-12", DateTimeZone.UTC).getMillis(),
+            DateTimeZone.getDefault())),
+          YamlDate(new DateTime(
+            new DateTime("2001-08-14", DateTimeZone.UTC).getMillis(),
+            DateTimeZone.getDefault())))))
+  }
 
-    "correctly parse in-line nested mapping" in withYaml("/examples/ex9.yaml") { yaml =>
-      yaml mustEqual YamlArray(
-        YamlObject(
-          YamlString("item") -> YamlString("Super Hoop"),
-          YamlString("quantity") -> YamlNumber(1)),
-        YamlObject(
-          YamlString("item") -> YamlString("Basketball"),
-          YamlString("quantity") -> YamlNumber(4)),
-        YamlObject(
-          YamlString("item") -> YamlString("Big Shoes"),
-          YamlString("quantity") -> YamlNumber(1)))
-    }
+  it should "correctly parse in-line nested mapping" in withYaml("/examples/ex9.yaml") { yaml =>
+    yaml should ===(YamlArray(
+      YamlObject(
+        YamlString("item") -> YamlString("Super Hoop"),
+        YamlString("quantity") -> YamlNumber(1)),
+      YamlObject(
+        YamlString("item") -> YamlString("Basketball"),
+        YamlString("quantity") -> YamlNumber(4)),
+      YamlObject(
+        YamlString("item") -> YamlString("Big Shoes"),
+        YamlString("quantity") -> YamlNumber(1))))
+  }
 
-    "correctly preserve new lines in literals" in withYaml("/examples/ex10.yaml") { yaml =>
-      yaml mustEqual YamlString(
-        """\//||\/||
+  it should "correctly preserve new lines in literals" in withYaml("/examples/ex10.yaml") { yaml =>
+    yaml should ===(YamlString(
+      """\//||\/||
             |// ||  ||__
-            |""".stripMargin)
-    }
+            |""".stripMargin))
+  }
 
-    "correctly replace newlines by spaces in plain scalar" in withYaml("/examples/ex11.yaml") { yaml =>
-      yaml mustEqual YamlString(
-        "Mark McGwire's year was crippled by a knee injury.")
-    }
+  it should "correctly replace newlines by spaces in plain scalar" in withYaml("/examples/ex11.yaml") { yaml =>
+    yaml should ===(YamlString("Mark McGwire's year was crippled by a knee injury."))
+  }
 
-    "correctly parse folded new lines" in withYaml("/examples/ex12.yaml") { yaml =>
-      yaml mustEqual YamlString(
-        """Sammy Sosa completed another fine season with great stats.
+  it should "correctly parse folded new lines" in withYaml("/examples/ex12.yaml") { yaml =>
+    yaml should ===(YamlString(
+      """Sammy Sosa completed another fine season with great stats.
             |
             |  63 Home Runs
             |  0.288 Batting Average
             |
             |What a year!
-            |""".stripMargin)
-    }
+            |""".stripMargin))
+  }
 
-    "correctly determine scope by indentation" in withYaml("/examples/ex13.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("name") ->
-          YamlString("Mark McGwire"),
-        YamlString("accomplishment") ->
-          YamlString("Mark set a major league home run record in 1998.\n"),
-        YamlString("stats") ->
-          YamlString("65 Home Runs\n0.278 Batting Average\n"))
-    }
+  it should "correctly determine scope by indentation" in withYaml("/examples/ex13.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("name") ->
+        YamlString("Mark McGwire"),
+      YamlString("accomplishment") ->
+        YamlString("Mark set a major league home run record in 1998.\n"),
+      YamlString("stats") ->
+        YamlString("65 Home Runs\n0.278 Batting Average\n")))
+  }
 
-    "correctly parse quoted scalars" in withYaml("/examples/ex14.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("unicode") ->
-          YamlString("Sosa did fine.\u263A"),
-        YamlString("control") ->
-          YamlString("\b1998\t1999\t2000\n"),
-        YamlString("hexesc") ->
-          YamlString("\u0013\u0010 is \r\n"),
-        YamlString("single") ->
-          YamlString(""""Howdy!" he cried."""),
-        YamlString("quoted") ->
-          YamlString(" # not a 'comment'."),
-        YamlString("tie-fighter") ->
-          YamlString("""|\-*-/|"""))
-    }
+  it should "correctly parse quoted scalars" in withYaml("/examples/ex14.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("unicode") ->
+        YamlString("Sosa did fine.\u263A"),
+      YamlString("control") ->
+        YamlString("\b1998\t1999\t2000\n"),
+      YamlString("hexesc") ->
+        YamlString("\u0013\u0010 is \r\n"),
+      YamlString("single") ->
+        YamlString(""""Howdy!" he cried."""),
+      YamlString("quoted") ->
+        YamlString(" # not a 'comment'."),
+      YamlString("tie-fighter") ->
+        YamlString("""|\-*-/|""")))
+  }
 
-    "correctly parse multi-line flow scalars" in withYaml("/examples/ex15.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("plain") ->
-          YamlString("This unquoted scalar spans many lines."),
-        YamlString("quoted") ->
-          YamlString("So does this quoted scalar.\n"))
-    }
+  it should "correctly parse multi-line flow scalars" in withYaml("/examples/ex15.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("plain") ->
+        YamlString("This unquoted scalar spans many lines."),
+      YamlString("quoted") ->
+        YamlString("So does this quoted scalar.\n")))
+  }
 
-    "correctly parse integers" in withYaml("/examples/ex16.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("canonical") ->
-          YamlNumber(12345),
-        YamlString("decimal") ->
-          YamlNumber(12345),
-        YamlString("sexagesimal") ->
-          YamlNumber(12345),
-        YamlString("octal") ->
-          YamlNumber(12),
-        YamlString("hexadecimal") ->
-          YamlNumber(12))
-    }
+  it should "correctly parse integers" in withYaml("/examples/ex16.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("canonical") ->
+        YamlNumber(12345),
+      YamlString("decimal") ->
+        YamlNumber(12345),
+      YamlString("sexagesimal") ->
+        YamlNumber(12345),
+      YamlString("octal") ->
+        YamlNumber(12),
+      YamlString("hexadecimal") ->
+        YamlNumber(12)))
+  }
 
-    "correctly parse large integers" in withYaml("/examples/ex16-2.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("long_canonical") ->
-          YamlNumber(21474836470L),
-        YamlString("bigint_canonical") ->
-          YamlNumber(BigInt("92233720368547758070")))
-    }
+  it should "correctly parse large integers" in withYaml("/examples/ex16-2.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("long_canonical") ->
+        YamlNumber(21474836470L),
+      YamlString("bigint_canonical") ->
+        YamlNumber(BigInt("92233720368547758070"))))
+  }
 
-    "correctly parse floating point numbers" in withYaml("/examples/ex17.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("canonical") ->
-          YamlNumber(1230.15),
-        YamlString("exponential") ->
-          YamlNumber(1230.15),
-        YamlString("sexagesimal") ->
-          YamlNumber(1230.15),
-        YamlString("fixed") ->
-          YamlNumber(1230.15))
-    }
+  it should "correctly parse floating point numbers" in withYaml("/examples/ex17.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("canonical") ->
+        YamlNumber(1230.15),
+      YamlString("exponential") ->
+        YamlNumber(1230.15),
+      YamlString("sexagesimal") ->
+        YamlNumber(1230.15),
+      YamlString("fixed") ->
+        YamlNumber(1230.15)))
+  }
 
-    "correctly parse miscellaneous scalars" in withYaml("/examples/ex18.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlNull ->
-          YamlNull,
-        YamlBoolean(true) ->
-          YamlString("y"),
-        YamlBoolean(false) ->
-          YamlString("n"),
-        YamlString("string") ->
-          YamlString("12345"))
-    }
+  it should "correctly parse miscellaneous scalars" in withYaml("/examples/ex18.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlNull ->
+        YamlNull,
+      YamlBoolean(true) ->
+        YamlString("y"),
+      YamlBoolean(false) ->
+        YamlString("n"),
+      YamlString("string") ->
+        YamlString("12345")))
+  }
 
-    "correctly parse timestamps" in withYaml("/examples/ex19.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("canonical") ->
-          YamlDate("2001-12-15T02:59:43.1Z".toDateTime),
-        YamlString("iso8601") ->
-          YamlDate("2001-12-14T21:59:43.10-05:00".toDateTime),
-        YamlString("spaced") ->
-          YamlDate("2001-12-14T21:59:43.10-05:00".toDateTime),
-        YamlString("date") ->
-          YamlDate(new DateTime(
-            new DateTime("2002-12-14", DateTimeZone.UTC).getMillis(),
-            DateTimeZone.getDefault())))
-    }
+  it should "correctly parse timestamps" in withYaml("/examples/ex19.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("canonical") ->
+        YamlDate("2001-12-15T02:59:43.1Z".toDateTime),
+      YamlString("iso8601") ->
+        YamlDate("2001-12-14T21:59:43.10-05:00".toDateTime),
+      YamlString("spaced") ->
+        YamlDate("2001-12-14T21:59:43.10-05:00".toDateTime),
+      YamlString("date") ->
+        YamlDate(new DateTime(
+          new DateTime("2002-12-14", DateTimeZone.UTC).getMillis(),
+          DateTimeZone.getDefault()))))
+  }
 
-    "correctly parse explicit sets" in withYaml("/examples/ex20.yaml") { yaml =>
-      yaml mustEqual YamlSet(
+  it should "correctly parse explicit sets" in withYaml("/examples/ex20.yaml") { yaml =>
+    yaml should ===(YamlSet(
+      YamlString("Mark McGwire"),
+      YamlString("Sammy Sosa"),
+      YamlString("Ken Griff")))
+  }
+
+  it should "correctly parse explicit ordered mappings" in withYaml("/examples/ex21.yaml") { yaml =>
+    yaml should ===(YamlObject(
+      YamlString("Mark McGwire") -> YamlNumber(65),
+      YamlString("Sammy Sosa") -> YamlNumber(63),
+      YamlString("Ken Griffy") -> YamlNumber(58)))
+  }
+
+  it should "correctly parse multiple documents in a stream" in withYamls("/examples/ex22.yaml") { yamls =>
+    yamls should ===(Seq(
+      YamlArray(
         YamlString("Mark McGwire"),
         YamlString("Sammy Sosa"),
-        YamlString("Ken Griff"))
-    }
-
-    "correctly parse explicit ordered mappings" in withYaml("/examples/ex21.yaml") { yaml =>
-      yaml mustEqual YamlObject(
-        YamlString("Mark McGwire") -> YamlNumber(65),
-        YamlString("Sammy Sosa") -> YamlNumber(63),
-        YamlString("Ken Griffy") -> YamlNumber(58))
-    }
-
-    "correctly parse multiple documents in a stream" in withYamls("/examples/ex22.yaml") { yamls =>
-      yamls mustEqual Seq(
-        YamlArray(
-          YamlString("Mark McGwire"),
-          YamlString("Sammy Sosa"),
-          YamlString("Ken Griffey")),
-        YamlArray(
-          YamlString("Chicago Cubs"),
-          YamlString("St Louis Cardinals")))
-    }
+        YamlString("Ken Griffey")),
+      YamlArray(
+        YamlString("Chicago Cubs"),
+        YamlString("St Louis Cardinals"))))
   }
 }

--- a/src/test/scala/net/jcazevedo/moultingyaml/YamlParserSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/YamlParserSpec.scala
@@ -1,15 +1,16 @@
 package net.jcazevedo.moultingyaml
 
-import com.github.nscala_time.time.Imports._
 import java.net.URLDecoder
 
 import scala.io.Source
 import scala.util.{ Failure, Success, Try }
 
+import com.github.nscala_time.time.Imports._
 import org.scalactic.source.Position
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
 
-class YamlParserSpec extends FlatSpec with Matchers {
+class YamlParserSpec extends FlatSpec {
   def getResourceURL(resource: String): String =
     URLDecoder.decode(getClass.getResource(resource).getFile, "UTF-8")
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
@@ -1,8 +1,9 @@
 package net.jcazevedo.moultingyaml
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
 
-class YamlPrettyPrinterSpec extends FlatSpec with Matchers {
+class YamlPrettyPrinterSpec extends FlatSpec {
   "The provided YAML prettyprinter" should "pretty print sequences of scalars" in {
     val yaml = YamlArray(
       YamlString("Mark McGwire"),

--- a/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
@@ -1,48 +1,47 @@
 package net.jcazevedo.moultingyaml
 
-import org.specs2.mutable._
+import org.scalatest.{ FlatSpec, Matchers }
 
-class YamlPrettyPrinterSpec extends Specification {
-  "The provided YAML prettyprinter" should {
-    "pretty print sequences of scalars" in {
-      val yaml = YamlArray(
-        YamlString("Mark McGwire"),
-        YamlString("Sammy Sosa"),
-        YamlString("Ken Griffey"))
+class YamlPrettyPrinterSpec extends FlatSpec with Matchers {
+  "The provided YAML prettyprinter" should "pretty print sequences of scalars" in {
+    val yaml = YamlArray(
+      YamlString("Mark McGwire"),
+      YamlString("Sammy Sosa"),
+      YamlString("Ken Griffey"))
 
-      yaml.prettyPrint mustEqual
-        """- Mark McGwire
+    yaml.prettyPrint should ===(
+      """- Mark McGwire
           |- Sammy Sosa
           |- Ken Griffey
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print yaml objects" in {
-      val yaml = YamlObject(
-        YamlString("hr") -> YamlNumber(65),
-        YamlString("avg") -> YamlNumber(0.278),
-        YamlString("rbi") -> YamlNumber(147))
+  it should "pretty print yaml objects" in {
+    val yaml = YamlObject(
+      YamlString("hr") -> YamlNumber(65),
+      YamlString("avg") -> YamlNumber(0.278),
+      YamlString("rbi") -> YamlNumber(147))
 
-      yaml.prettyPrint mustEqual
-        """hr: 65
+    yaml.prettyPrint should ===(
+      """hr: 65
           |avg: 0.278
           |rbi: 147
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print yaml objects with sequences on it" in {
-      val yaml = YamlObject(
-        YamlString("american") -> YamlArray(
-          YamlString("Boston Red Sox"),
-          YamlString("Detroit Tigers"),
-          YamlString("New York Yankees")),
-        YamlString("national") -> YamlArray(
-          YamlString("New York Mets"),
-          YamlString("Chicago Cubs"),
-          YamlString("Atlanta Braves")))
+  it should "pretty print yaml objects with sequences on it" in {
+    val yaml = YamlObject(
+      YamlString("american") -> YamlArray(
+        YamlString("Boston Red Sox"),
+        YamlString("Detroit Tigers"),
+        YamlString("New York Yankees")),
+      YamlString("national") -> YamlArray(
+        YamlString("New York Mets"),
+        YamlString("Chicago Cubs"),
+        YamlString("Atlanta Braves")))
 
-      yaml.prettyPrint mustEqual
-        """american:
+    yaml.prettyPrint should ===(
+      """american:
           |- Boston Red Sox
           |- Detroit Tigers
           |- New York Yankees
@@ -50,47 +49,47 @@ class YamlPrettyPrinterSpec extends Specification {
           |- New York Mets
           |- Chicago Cubs
           |- Atlanta Braves
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print sequences of mappings" in {
-      val yaml = YamlArray(
-        YamlObject(
-          YamlString("name") -> YamlString("Mark McGwire"),
-          YamlString("hr") -> YamlNumber(65),
-          YamlString("avg") -> YamlNumber(0.278)),
-        YamlObject(
-          YamlString("name") -> YamlString("Sammy Sosa"),
-          YamlString("hr") -> YamlNumber(63),
-          YamlString("avg") -> YamlNumber(0.288)))
+  it should "pretty print sequences of mappings" in {
+    val yaml = YamlArray(
+      YamlObject(
+        YamlString("name") -> YamlString("Mark McGwire"),
+        YamlString("hr") -> YamlNumber(65),
+        YamlString("avg") -> YamlNumber(0.278)),
+      YamlObject(
+        YamlString("name") -> YamlString("Sammy Sosa"),
+        YamlString("hr") -> YamlNumber(63),
+        YamlString("avg") -> YamlNumber(0.288)))
 
-      yaml.prettyPrint mustEqual
-        """- name: Mark McGwire
+    yaml.prettyPrint should ===(
+      """- name: Mark McGwire
           |  hr: 65
           |  avg: 0.278
           |- name: Sammy Sosa
           |  hr: 63
           |  avg: 0.288
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print sequences of sequences" in {
-      val yaml = YamlArray(
-        YamlArray(
-          YamlString("name"),
-          YamlString("hr"),
-          YamlString("avg")),
-        YamlArray(
-          YamlString("Mark McGwire"),
-          YamlNumber(65),
-          YamlNumber(0.278)),
-        YamlArray(
-          YamlString("Sammy Sosa"),
-          YamlNumber(63),
-          YamlNumber(0.288)))
+  it should "pretty print sequences of sequences" in {
+    val yaml = YamlArray(
+      YamlArray(
+        YamlString("name"),
+        YamlString("hr"),
+        YamlString("avg")),
+      YamlArray(
+        YamlString("Mark McGwire"),
+        YamlNumber(65),
+        YamlNumber(0.278)),
+      YamlArray(
+        YamlString("Sammy Sosa"),
+        YamlNumber(63),
+        YamlNumber(0.288)))
 
-      yaml.prettyPrint mustEqual
-        """- - name
+    yaml.prettyPrint should ===(
+      """- - name
           |  - hr
           |  - avg
           |- - Mark McGwire
@@ -99,45 +98,45 @@ class YamlPrettyPrinterSpec extends Specification {
           |- - Sammy Sosa
           |  - 63
           |  - 0.288
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print mappings of mappings" in {
-      val yaml = YamlObject(
-        YamlString("Mark McGwire") -> YamlObject(
-          YamlString("hr") -> YamlNumber(65),
-          YamlString("avg") -> YamlNumber(0.278)),
-        YamlString("Sammy Sosa") -> YamlObject(
-          YamlString("hr") -> YamlNumber(63),
-          YamlString("avg") -> YamlNumber(0.288)))
+  it should "pretty print mappings of mappings" in {
+    val yaml = YamlObject(
+      YamlString("Mark McGwire") -> YamlObject(
+        YamlString("hr") -> YamlNumber(65),
+        YamlString("avg") -> YamlNumber(0.278)),
+      YamlString("Sammy Sosa") -> YamlObject(
+        YamlString("hr") -> YamlNumber(63),
+        YamlString("avg") -> YamlNumber(0.288)))
 
-      yaml.prettyPrint mustEqual
-        """Mark McGwire:
+    yaml.prettyPrint should ===(
+      """Mark McGwire:
           |  hr: 65
           |  avg: 0.278
           |Sammy Sosa:
           |  hr: 63
           |  avg: 0.288
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print mappings between sequences" in {
-      val yaml = YamlObject(
+  it should "pretty print mappings between sequences" in {
+    val yaml = YamlObject(
+      YamlArray(
+        YamlString("Detroit Tigers"),
+        YamlString("Chicago cubs")) ->
         YamlArray(
-          YamlString("Detroit Tigers"),
-          YamlString("Chicago cubs")) ->
-          YamlArray(
-            YamlString("2001-07-23")),
+          YamlString("2001-07-23")),
+      YamlArray(
+        YamlString("New York Yankees"),
+        YamlString("Atlanta Braves")) ->
         YamlArray(
-          YamlString("New York Yankees"),
-          YamlString("Atlanta Braves")) ->
-          YamlArray(
-            YamlString("2001-07-02"),
-            YamlString("2001-08-12"),
-            YamlString("2001-08-14")))
+          YamlString("2001-07-02"),
+          YamlString("2001-08-12"),
+          YamlString("2001-08-14")))
 
-      yaml.prettyPrint mustEqual
-        """? - Detroit Tigers
+    yaml.prettyPrint should ===(
+      """? - Detroit Tigers
           |  - Chicago cubs
           |: - '2001-07-23'
           |? - New York Yankees
@@ -145,23 +144,23 @@ class YamlPrettyPrinterSpec extends Specification {
           |: - '2001-07-02'
           |  - '2001-08-12'
           |  - '2001-08-14'
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print strings with newlines" in {
-      val yaml1 = YamlString(
-        """\//||\/||
+  it should "pretty print strings with newlines" in {
+    val yaml1 = YamlString(
+      """\//||\/||
           |// ||  ||__
           |""".stripMargin)
 
-      yaml1.prettyPrint mustEqual
-        """||
+    yaml1.prettyPrint should ===(
+      """||
           |  \//||\/||
           |  // ||  ||__
-          |""".stripMargin
+          |""".stripMargin)
 
-      val yaml2 = YamlString(
-        """Sammy Sosa completed another fine season with great stats.
+    val yaml2 = YamlString(
+      """Sammy Sosa completed another fine season with great stats.
           |
           |  63 Home Runs
           |  0.288 Batting Average
@@ -169,131 +168,130 @@ class YamlPrettyPrinterSpec extends Specification {
           |What a year!
           |""".stripMargin)
 
-      yaml2.prettyPrint mustEqual
-        """||
+    yaml2.prettyPrint should ===(
+      """||
           |  Sammy Sosa completed another fine season with great stats.
           |
           |    63 Home Runs
           |    0.288 Batting Average
           |
           |  What a year!
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print numbers" in {
-      val yaml = YamlObject(
-        YamlString("int") ->
-          YamlNumber(42),
-        YamlString("float") ->
-          YamlNumber(0.4555),
-        YamlString("long_canonical") ->
-          YamlNumber(21474836470L),
-        YamlString("bigint_canonical") ->
-          YamlNumber(BigInt("92233720368547758070")))
+  it should "pretty print numbers" in {
+    val yaml = YamlObject(
+      YamlString("int") ->
+        YamlNumber(42),
+      YamlString("float") ->
+        YamlNumber(0.4555),
+      YamlString("long_canonical") ->
+        YamlNumber(21474836470L),
+      YamlString("bigint_canonical") ->
+        YamlNumber(BigInt("92233720368547758070")))
 
-      yaml.prettyPrint mustEqual
-        """int: 42
+    yaml.prettyPrint should ===(
+      """int: 42
           |float: 0.4555
           |long_canonical: 21474836470
           |bigint_canonical: 92233720368547758070
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print miscellaneous scalars" in {
-      val yaml = YamlObject(
-        YamlNull ->
-          YamlNull,
-        YamlBoolean(true) ->
-          YamlString("y"),
-        YamlBoolean(false) ->
-          YamlString("n"),
-        YamlString("string") ->
-          YamlString("12345"))
+  it should "pretty print miscellaneous scalars" in {
+    val yaml = YamlObject(
+      YamlNull ->
+        YamlNull,
+      YamlBoolean(true) ->
+        YamlString("y"),
+      YamlBoolean(false) ->
+        YamlString("n"),
+      YamlString("string") ->
+        YamlString("12345"))
 
-      yaml.prettyPrint mustEqual
-        """null: null
+    yaml.prettyPrint should ===(
+      """null: null
           |true: y
           |false: n
           |string: '12345'
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "pretty print explicit sets" in {
-      val yaml = YamlSet(
-        YamlString("Mark McGwire"),
-        YamlString("Sammy Sosa"),
-        YamlString("Ken Griff"))
+  it should "pretty print explicit sets" in {
+    val yaml = YamlSet(
+      YamlString("Mark McGwire"),
+      YamlString("Sammy Sosa"),
+      YamlString("Ken Griff"))
 
-      yaml.prettyPrint mustEqual
-        """!!set
+    yaml.prettyPrint should ===(
+      """!!set
           |Mark McGwire: null
           |Sammy Sosa: null
           |Ken Griff: null
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "print according to a provided configuration" in {
-      val yaml = YamlObject(
-        YamlString("int") ->
-          YamlNumber(42),
-        YamlString("float") ->
-          YamlNumber(0.4555),
-        YamlString("long_canonical") ->
-          YamlNumber(21474836470L),
-        YamlString("bigint_canonical") ->
-          YamlNumber(BigInt("92233720368547758070")))
+  it should "print according to a provided configuration" in {
+    val yaml = YamlObject(
+      YamlString("int") ->
+        YamlNumber(42),
+      YamlString("float") ->
+        YamlNumber(0.4555),
+      YamlString("long_canonical") ->
+        YamlNumber(21474836470L),
+      YamlString("bigint_canonical") ->
+        YamlNumber(BigInt("92233720368547758070")))
 
-      yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)) mustEqual
-        """"int": !!int "42"
+    yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)) should ===(
+      """"int": !!int "42"
           |"float": !!float "0.4555"
           |"long_canonical": !!int "21474836470"
           |"bigint_canonical": !!int "92233720368547758070"
-          |""".stripMargin
-    }
+          |""".stripMargin)
+  }
 
-    "print with custom scalar style" in {
-      val yaml = YamlObject(
-        YamlString("int") ->
-          YamlNumber(42),
-        YamlString("float") ->
-          YamlNumber(0.4555),
-        YamlString("long_canonical") ->
-          YamlNumber(21474836470L),
-        YamlString("bigint_canonical") ->
-          YamlNumber(BigInt("92233720368547758070")))
+  it should "print with custom scalar style" in {
+    val yaml = YamlObject(
+      YamlString("int") ->
+        YamlNumber(42),
+      YamlString("float") ->
+        YamlNumber(0.4555),
+      YamlString("long_canonical") ->
+        YamlNumber(21474836470L),
+      YamlString("bigint_canonical") ->
+        YamlNumber(BigInt("92233720368547758070")))
 
-      yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)) mustEqual
-        yaml.print(new SnakeYamlPrinter(scalarStyle = ScalarStyle.createStyle('"')))
-    }
+    yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)) should ===(
+      yaml.print(new SnakeYamlPrinter(scalarStyle = ScalarStyle.createStyle('"'))))
+  }
 
-    "print with default configuration" in {
-      val yaml = YamlObject(
-        YamlString("int") ->
-          YamlNumber(42),
-        YamlString("float") ->
-          YamlNumber(0.4555),
-        YamlString("long_canonical") ->
-          YamlNumber(21474836470L),
-        YamlString("bigint_canonical") ->
-          YamlNumber(BigInt("92233720368547758070")))
+  it should "print with default configuration" in {
+    val yaml = YamlObject(
+      YamlString("int") ->
+        YamlNumber(42),
+      YamlString("float") ->
+        YamlNumber(0.4555),
+      YamlString("long_canonical") ->
+        YamlNumber(21474836470L),
+      YamlString("bigint_canonical") ->
+        YamlNumber(BigInt("92233720368547758070")))
 
-      yaml.print mustEqual yaml.prettyPrint
-    }
+    yaml.print should ===(yaml.prettyPrint)
+  }
 
-    "print can use an implicit YamlPrinter" in {
-      val yaml = YamlObject(
-        YamlString("int") ->
-          YamlNumber(42),
-        YamlString("float") ->
-          YamlNumber(0.4555),
-        YamlString("long_canonical") ->
-          YamlNumber(21474836470L),
-        YamlString("bigint_canonical") ->
-          YamlNumber(BigInt("92233720368547758070")))
+  it should "print can use an implicit YamlPrinter" in {
+    val yaml = YamlObject(
+      YamlString("int") ->
+        YamlNumber(42),
+      YamlString("float") ->
+        YamlNumber(0.4555),
+      YamlString("long_canonical") ->
+        YamlNumber(21474836470L),
+      YamlString("bigint_canonical") ->
+        YamlNumber(BigInt("92233720368547758070")))
 
-      implicit val yamlPrinter = new SnakeYamlPrinter(scalarStyle = DoubleQuoted)
+    implicit val yamlPrinter = new SnakeYamlPrinter(scalarStyle = DoubleQuoted)
 
-      yaml.print mustEqual yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted))
-    }
+    yaml.print should ===(yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)))
   }
 }


### PR DESCRIPTION
## Add scala 2.13

- Removed 2.10.x because it conflicts with `specs2-core`(4.5.1  don't have an artifact for 2.10)
- Updates plugins to the lates versions