### PR TITLE
Upgraded to SBT 1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,11 +29,9 @@ scalacOptions ++= Seq(
 scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Ywarn-unused-import"))
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
-scalariformSettings
-
-ScalariformKeys.preferences := ScalariformKeys.preferences.value
+scalariformPreferences := scalariformPreferences.value
   .setPreference(AlignParameters, true)
-  .setPreference(DoubleIndentClassDeclaration, true)
+  .setPreference(DoubleIndentConstructorArguments, true)
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ scalacOptions in (Compile, console) ~= (_ filterNot (Set("-Ywarn-unused:imports"
 scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
 scalariformPreferences := scalariformPreferences.value
-  .setPreference(AlignParameters, true)
+  .setPreference(DanglingCloseParenthesis, Prevent)
   .setPreference(DoubleIndentConstructorArguments, true)
 
 publishMavenStyle := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.4.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
@@ -1056,18 +1056,18 @@ trait ProductFormats {
   }
 
   protected[this] def writeField[A: YamlWriter](
-    value:     Any,
+    value: Any,
     fieldName: String,
-    isOption:  Boolean): Option[(YamlString, YamlValue)] = value match {
+    isOption: Boolean): Option[(YamlString, YamlValue)] = value match {
 
     case None => None
     case _ => Some(YamlString(fieldName) -> value.asInstanceOf[A].toYaml)
   }
 
   protected[this] def readField[A: YamlReader](
-    value:     YamlValue,
+    value: YamlValue,
     fieldName: String,
-    isOption:  Boolean) = value match {
+    isOption: Boolean) = value match {
 
     case YamlObject(fields) if isOption &&
       !fields.contains(YamlString(fieldName)) => None.asInstanceOf[A]

--- a/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/ProductFormats.scala
@@ -1046,7 +1046,7 @@ trait ProductFormats {
       _.getName.drop("copy$default$".length).takeWhile(_ != '(').toInt)
     val fields = clazz.getDeclaredFields.filterNot { f =>
       import Modifier._
-        (f.getModifiers & (TRANSIENT | STATIC | 0x1000)) > 0
+      (f.getModifiers & (TRANSIENT | STATIC | 0x1000)) > 0
     }
     if (copyDefaultMethods.length != fields.length)
       sys.error("Case class " + clazz.getName + " declares additional fields")
@@ -1056,18 +1056,18 @@ trait ProductFormats {
   }
 
   protected[this] def writeField[A: YamlWriter](
-    value: Any,
+    value:     Any,
     fieldName: String,
-    isOption: Boolean): Option[(YamlString, YamlValue)] = value match {
+    isOption:  Boolean): Option[(YamlString, YamlValue)] = value match {
 
     case None => None
     case _ => Some(YamlString(fieldName) -> value.asInstanceOf[A].toYaml)
   }
 
   protected[this] def readField[A: YamlReader](
-    value: YamlValue,
+    value:     YamlValue,
     fieldName: String,
-    isOption: Boolean) = value match {
+    isOption:  Boolean) = value match {
 
     case YamlObject(fields) if isOption &&
       !fields.contains(YamlString(fieldName)) => None.asInstanceOf[A]
@@ -1084,7 +1084,8 @@ trait ProductFormats {
       }
 
     case other =>
-      deserializationError("YamlObject expected, but got " + other,
+      deserializationError(
+        "YamlObject expected, but got " + other,
         fieldNames = fieldName :: Nil)
   }
 }
@@ -1095,8 +1096,7 @@ object ProductFormats {
       val res = NameTransformer.decode(s)
       if (res == s) s
       else res
-    }
-    else s
+    } else s
   }
 }
 

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
@@ -76,15 +76,16 @@ case object Unix extends LineBreak {
 }
 
 abstract class YamlPrinter(
-  flowStyle: FlowStyle, scalarStyle: ScalarStyle, lineBreak: LineBreak)
-    extends (YamlValue => String) {
+    flowStyle: FlowStyle, scalarStyle: ScalarStyle, lineBreak: LineBreak)
+  extends (YamlValue => String) {
   def apply(value: YamlValue): String
 }
 
-class SnakeYamlPrinter(flowStyle: FlowStyle = FlowStyle.DEFAULT,
-                       scalarStyle: ScalarStyle = ScalarStyle.DEFAULT,
-                       lineBreak: LineBreak = LineBreak.DEFAULT)
-    extends YamlPrinter(flowStyle, scalarStyle, lineBreak) {
+class SnakeYamlPrinter(
+    flowStyle:   FlowStyle   = FlowStyle.DEFAULT,
+    scalarStyle: ScalarStyle = ScalarStyle.DEFAULT,
+    lineBreak:   LineBreak   = LineBreak.DEFAULT)
+  extends YamlPrinter(flowStyle, scalarStyle, lineBreak) {
 
   def dumperOptions: DumperOptions = {
     val dp = new DumperOptions

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlPrinter.scala
@@ -82,9 +82,9 @@ abstract class YamlPrinter(
 }
 
 class SnakeYamlPrinter(
-    flowStyle:   FlowStyle   = FlowStyle.DEFAULT,
+    flowStyle: FlowStyle = FlowStyle.DEFAULT,
     scalarStyle: ScalarStyle = ScalarStyle.DEFAULT,
-    lineBreak:   LineBreak   = LineBreak.DEFAULT)
+    lineBreak: LineBreak = LineBreak.DEFAULT)
   extends YamlPrinter(flowStyle, scalarStyle, lineBreak) {
 
   def dumperOptions: DumperOptions = {

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -10,16 +10,18 @@ package object moultingyaml {
   private[moultingyaml] type YF[A] = YamlFormat[A]
   // format: ON
 
-  case class DeserializationException(msg: String,
-                                      cause: Throwable = null,
-                                      fieldNames: List[String] = Nil)
-      extends RuntimeException(msg, cause)
+  case class DeserializationException(
+      msg:        String,
+      cause:      Throwable    = null,
+      fieldNames: List[String] = Nil)
+    extends RuntimeException(msg, cause)
 
   case class SerializationException(msg: String) extends RuntimeException(msg)
 
-  def deserializationError(msg: String,
-                           cause: Throwable = null,
-                           fieldNames: List[String] = Nil) =
+  def deserializationError(
+    msg:        String,
+    cause:      Throwable    = null,
+    fieldNames: List[String] = Nil) =
     throw new DeserializationException(msg, cause, fieldNames)
 
   def serializationError(msg: String) = throw new SerializationException(msg)

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -11,16 +11,16 @@ package object moultingyaml {
   // format: ON
 
   case class DeserializationException(
-      msg:        String,
-      cause:      Throwable    = null,
+      msg: String,
+      cause: Throwable = null,
       fieldNames: List[String] = Nil)
     extends RuntimeException(msg, cause)
 
   case class SerializationException(msg: String) extends RuntimeException(msg)
 
   def deserializationError(
-    msg:        String,
-    cause:      Throwable    = null,
+    msg: String,
+    cause: Throwable = null,
     fieldNames: List[String] = Nil) =
     throw new DeserializationException(msg, cause, fieldNames)
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
@@ -3,7 +3,7 @@ package net.jcazevedo.moultingyaml
 import org.specs2.mutable._
 
 class CollectionFormatsSpec extends Specification with CollectionFormats
-    with BasicFormats {
+  with BasicFormats {
 
   "The listFormat" should {
     val list = List(1, 2, 3)

--- a/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/CollectionFormatsSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 
 class CollectionFormatsSpec extends FlatSpec with CollectionFormats
-    with BasicFormats {
+  with BasicFormats {
 
   {
     val list = List(1, 2, 3)

--- a/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
@@ -66,13 +66,15 @@ class ProductFormatsSpec extends Specification {
     }
 
     "ignore additional members during deserialization" in {
-      YamlObject(YamlString("a") -> YamlNumber(42),
+      YamlObject(
+        YamlString("a") -> YamlNumber(42),
         YamlString("b") -> YamlNumber(4.2),
         YamlString("c") -> YamlString("no")).convertTo[Test2] mustEqual obj
     }
 
     "not depend on any specific member order for deserialization" in {
-      YamlObject(YamlString("b") -> YamlNumber(4.2),
+      YamlObject(
+        YamlString("b") -> YamlNumber(4.2),
         YamlString("a") -> YamlNumber(42)).convertTo[Test2] mustEqual obj
     }
 
@@ -139,7 +141,8 @@ class ProductFormatsSpec extends Specification {
 
   "A YamlFormat for a case class with transient fields and created with `yamlFormat`" should {
     val obj = TestTransient(42, Some(4.2))
-    val yaml = YamlObject(YamlString("a") -> YamlNumber(42),
+    val yaml = YamlObject(
+      YamlString("a") -> YamlNumber(42),
       YamlString("b") -> YamlNumber(4.2))
 
     "convert to a respective YamlObject" in {
@@ -153,7 +156,8 @@ class ProductFormatsSpec extends Specification {
 
   "A YamlFormat for a case class with static fields and created with `yamlFormat`" should {
     val obj = TestStatic(42, Some(4.2))
-    val yaml = YamlObject(YamlString("a") -> YamlNumber(42),
+    val yaml = YamlObject(
+      YamlString("a") -> YamlNumber(42),
       YamlString("b") -> YamlNumber(4.2))
 
     "convert to a respective YamlObject" in {
@@ -208,7 +212,8 @@ class ProductFormatsSpec extends Specification {
 
   "A YamlFormat created with `yamlFormat`, for a case class with 22 elements," should {
     val obj = Test5(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)
-    val yaml = YamlObject(YamlString("a1") -> YamlNumber(1),
+    val yaml = YamlObject(
+      YamlString("a1") -> YamlNumber(1),
       YamlString("a2") -> YamlNumber(2),
       YamlString("a3") -> YamlNumber(3),
       YamlString("a4") -> YamlNumber(4),

--- a/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/ProductFormatsSpec.scala
@@ -12,9 +12,9 @@ class ProductFormatsSpec extends FlatSpec {
   case class Test3[A, B](as: List[A], bs: List[B])
   case class Test4(t2: Test2)
   case class Test5(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int,
-                   a7: Int, a8: Int, a9: Int, a10: Int, a11: Int, a12: Int,
-                   a13: Int, a14: Int, a15: Int, a16: Int, a17: Int, a18: Int,
-                   a19: Int, a20: Int, a21: Int, a22: Int)
+      a7: Int, a8: Int, a9: Int, a10: Int, a11: Int, a12: Int,
+      a13: Int, a14: Int, a15: Int, a16: Int, a17: Int, a18: Int,
+      a19: Int, a20: Int, a21: Int, a22: Int)
   case class TestTransient(a: Int, b: Option[Double]) {
     @transient var c = false
   }
@@ -22,8 +22,8 @@ class ProductFormatsSpec extends FlatSpec {
   @SerialVersionUID(1L) // SerialVersionUID adds a static field to the case class
   case class TestStatic(a: Int, b: Option[Double])
   case class TestMangled(`foo-bar!`: Int, `User ID`: String,
-                         `ü$bavf$u56ú$`: Boolean, `-x-`: Int,
-                         `=><+-*/!@#%^&~?|`: Float)
+      `ü$bavf$u56ú$`: Boolean, `-x-`: Int,
+      `=><+-*/!@#%^&~?|`: Float)
 
   trait TestProtocol extends DefaultYamlProtocol {
     implicit val test0Format = yamlFormat0(Test0)
@@ -68,13 +68,15 @@ class ProductFormatsSpec extends FlatSpec {
     }
 
     it should "ignore additional members during deserialization" in {
-      YamlObject(YamlString("a") -> YamlNumber(42),
+      YamlObject(
+        YamlString("a") -> YamlNumber(42),
         YamlString("b") -> YamlNumber(4.2),
         YamlString("c") -> YamlString("no")).convertTo[Test2] should ===(obj)
     }
 
     it should "not depend on any specific member order for deserialization" in {
-      YamlObject(YamlString("b") -> YamlNumber(4.2),
+      YamlObject(
+        YamlString("b") -> YamlNumber(4.2),
         YamlString("a") -> YamlNumber(42)).convertTo[Test2] should ===(obj)
     }
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
@@ -3,7 +3,7 @@ package net.jcazevedo.moultingyaml
 import org.specs2.mutable._
 
 class StandardFormatsSpec extends Specification with StandardFormats
-    with BasicFormats {
+  with BasicFormats {
 
   "The optionFormat" should {
 

--- a/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/StandardFormatsSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 
 class StandardFormatsSpec extends FlatSpec with StandardFormats
-    with BasicFormats {
+  with BasicFormats {
 
   "The optionFormat" should "convert None to YamlNull" in {
     None.asInstanceOf[Option[Int]].toYaml should ===(YamlNull)


### PR DESCRIPTION
Upgraded SBT to 1.2 and made the changes required to do so.

On my system, it also fixes this error (produced when entering SBT's REPL):

```
[ERROR] Failed to construct terminal; falling back to unsupported
java.lang.NumberFormatException: For input string: "0x100"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.valueOf(Integer.java:766)
	at jline.internal.InfoCmp.parseInfoCmp(InfoCmp.java:59)
	at jline.UnixTerminal.parseInfoCmp(UnixTerminal.java:233)
	at jline.UnixTerminal.<init>(UnixTerminal.java:64)
	at jline.UnixTerminal.<init>(UnixTerminal.java:49)
	at sun.reflect.GeneratedConstructorAccessor5.newInstance(Unknown Source)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at jline.TerminalFactory.getFlavor(TerminalFactory.java:209)
	at jline.TerminalFactory.create(TerminalFactory.java:100)
	at jline.TerminalFactory.get(TerminalFactory.java:184)
	at jline.TerminalFactory.get(TerminalFactory.java:190)
	at sbt.JLine$.sbt$JLine$$terminal(LineReader.scala:85)
	at sbt.JLine$.withTerminal(LineReader.scala:88)
	at sbt.JLine$.usingTerminal(LineReader.scala:96)
	at sbt.JLine$.createReader(LineReader.scala:102)
	at sbt.FullReader.<init>(LineReader.scala:132)
	at sbt.BasicCommands$$anonfun$shell$1.apply(BasicCommands.scala:184)
	at sbt.BasicCommands$$anonfun$shell$1.apply(BasicCommands.scala:181)
	at sbt.Command$$anonfun$command$1$$anonfun$apply$1.apply(Command.scala:30)
	at sbt.Command$$anonfun$command$1$$anonfun$apply$1.apply(Command.scala:30)
	at sbt.Command$.process(Command.scala:93)
	at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:96)
	at sbt.MainLoop$$anonfun$1$$anonfun$apply$1.apply(MainLoop.scala:96)
	at sbt.State$$anon$1.process(State.scala:184)
	at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:96)
	at sbt.MainLoop$$anonfun$1.apply(MainLoop.scala:96)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.MainLoop$.next(MainLoop.scala:96)
	at sbt.MainLoop$.run(MainLoop.scala:89)
	at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:68)
	at sbt.MainLoop$$anonfun$runWithNewLog$1.apply(MainLoop.scala:63)
	at sbt.Using.apply(Using.scala:24)
	at sbt.MainLoop$.runWithNewLog(MainLoop.scala:63)
	at sbt.MainLoop$.runAndClearLast(MainLoop.scala:46)
	at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:30)
	at sbt.MainLoop$.runLogged(MainLoop.scala:22)
	at sbt.StandardMain$.runManaged(Main.scala:57)
	at sbt.xMain.run(Main.scala:29)
	at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
	at xsbt.boot.Launch$.withContextLoader(Launch.scala:128)
	at xsbt.boot.Launch$.run(Launch.scala:109)
	at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:35)
	at xsbt.boot.Launch$.launch(Launch.scala:117)
	at xsbt.boot.Launch$.apply(Launch.scala:18)
	at xsbt.boot.Boot$.runImpl(Boot.scala:56)
	at xsbt.boot.Boot$.main(Boot.scala:18)
	at xsbt.boot.Boot.main(Boot.scala)
```