### PR TITLE
preserve object order in YamlObject

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/CollectionFormats.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/CollectionFormats.scala
@@ -48,7 +48,7 @@ trait CollectionFormats {
    */
   implicit def mapFormat[K: YF, V: YF]: YF[Map[K, V]] = new YF[Map[K, V]] {
     def write(m: Map[K, V]) =
-      YamlObject(m.map { case (k, v) => k.toYaml -> v.toYaml })
+      YamlObject(m.map { case (k, v) => k.toYaml -> v.toYaml }.toList: _*)
 
     def read(value: YamlValue) = value match {
       case x: YamlObject =>

--- a/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/YamlValue.scala
@@ -2,6 +2,7 @@ package net.jcazevedo.moultingyaml
 
 import com.github.nscala_time.time.Imports._
 import scala.collection.JavaConverters._
+import scala.collection.immutable.ListMap
 
 /**
  * The general type of a YAML AST node.
@@ -27,7 +28,7 @@ object YamlValue {
 /**
  * A YAML mapping from scalars to scalars.
  */
-case class YamlObject(fields: Map[YamlValue, YamlValue]) extends YamlValue {
+case class YamlObject(fields: ListMap[YamlValue, YamlValue]) extends YamlValue {
   override def asYamlObject(errorMsg: String) = this
 
   def getFields(fieldKeys: YamlValue*): Seq[YamlValue] =
@@ -42,7 +43,7 @@ case class YamlObject(fields: Map[YamlValue, YamlValue]) extends YamlValue {
 }
 
 object YamlObject {
-  def apply(fields: (YamlValue, YamlValue)*) = new YamlObject(Map(fields: _*))
+  def apply(fields: (YamlValue, YamlValue)*) = new YamlObject(ListMap(fields: _*))
 }
 
 /**

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -31,7 +31,7 @@ package object moultingyaml {
       case m: java.util.Map[Object @unchecked, Object @unchecked] =>
         YamlObject(m.asScala.map {
           case (k, v) => convertToYamlValue(k) -> convertToYamlValue(v)
-        }.toMap)
+        }.toList: _*)
       case l: java.util.List[Object @unchecked] =>
         YamlArray(l.asScala.map(convertToYamlValue).toVector)
       case s: java.util.Set[Object @unchecked] =>

--- a/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
+++ b/src/test/scala/net/jcazevedo/moultingyaml/YamlPrettyPrinterSpec.scala
@@ -295,4 +295,29 @@ class YamlPrettyPrinterSpec extends FlatSpec {
 
     yaml.print should ===(yaml.print(new SnakeYamlPrinter(scalarStyle = DoubleQuoted)))
   }
+
+  it should "print object in order" in {
+    val yaml = YamlObject(
+      YamlString("k1") -> YamlString("v1"),
+      YamlString("k2") -> YamlString("v2"),
+      YamlString("k3") -> YamlString("v3"),
+      YamlString("k4") -> YamlString("v4"),
+      YamlString("k5") -> YamlString("v5"),
+      YamlString("k6") -> YamlString("v6"),
+      YamlString("k7") -> YamlString("v7"),
+      YamlString("k8") -> YamlString("v8"),
+      YamlString("k9") -> YamlString("v9"))
+
+    yaml.print should ===(
+      """k1: v1
+        |k2: v2
+        |k3: v3
+        |k4: v4
+        |k5: v5
+        |k6: v6
+        |k7: v7
+        |k8: v8
+        |k9: v9
+        |""".stripMargin)
+  }
 }


### PR DESCRIPTION
Refs #38 

Using `ListMap` instead of `Map` should preserve the order of objects in `YamlObject`.