### PR TITLE
Upgrade to snakeyaml 1.26 to prevent Billion laughs attack

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12", "2.10.7")
 libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time"   % "2.22.0",
   "org.scala-lang"          % "scala-reflect" % scalaVersion.value,
-  "org.yaml"                % "snakeyaml"     % "1.24",
+  "org.yaml"                % "snakeyaml"     % "1.26",
   "org.scalatest"          %% "scalatest"     % "3.0.8"  % "test")
 
 scalacOptions ++= Seq(

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -64,15 +64,27 @@ package object moultingyaml {
 
   implicit class PimpedString(val string: String) extends AnyVal {
     def parseYaml: YamlValue =
-      parseYaml(new LoaderOptions())
+      parseYaml()
 
-    def parseYaml(loaderOptions: LoaderOptions) =
+    def parseYaml(allowDuplicateKeys: Boolean = true, allowRecursiveKeys: Boolean = false, wrappedToRootException: Boolean = false, maxAliasesForCollections: Int = 50) = {
+      val loaderOptions = new LoaderOptions()
+      loaderOptions.setAllowDuplicateKeys(allowDuplicateKeys)
+      loaderOptions.setAllowRecursiveKeys(allowRecursiveKeys)
+      loaderOptions.setWrappedToRootException(wrappedToRootException)
+      loaderOptions.setMaxAliasesForCollections(maxAliasesForCollections)
       convertToYamlValue(new Yaml(loaderOptions).load(string))
+    }
 
     def parseYamls: Seq[YamlValue] =
-      parseYamls(new LoaderOptions())
+      parseYamls()
 
-    def parseYamls(loaderOptions: LoaderOptions) =
+    def parseYamls(allowDuplicateKeys: Boolean = true, allowRecursiveKeys: Boolean = false, wrappedToRootException: Boolean = false, maxAliasesForCollections: Int = 50) = {
+      val loaderOptions = new LoaderOptions()
+      loaderOptions.setAllowDuplicateKeys(allowDuplicateKeys)
+      loaderOptions.setAllowRecursiveKeys(allowRecursiveKeys)
+      loaderOptions.setWrappedToRootException(wrappedToRootException)
+      loaderOptions.setMaxAliasesForCollections(maxAliasesForCollections)
       new Yaml(loaderOptions).loadAll(string).asScala.map(convertToYamlValue).toSeq
+    }
   }
 }

--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -1,7 +1,8 @@
 package net.jcazevedo
 
 import com.github.nscala_time.time.Imports._
-import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.{ LoaderOptions, Yaml }
+
 import scala.collection.JavaConverters._
 
 package object moultingyaml {
@@ -63,9 +64,15 @@ package object moultingyaml {
 
   implicit class PimpedString(val string: String) extends AnyVal {
     def parseYaml: YamlValue =
-      convertToYamlValue(new Yaml().load(string))
+      parseYaml(new LoaderOptions())
+
+    def parseYaml(loaderOptions: LoaderOptions) =
+      convertToYamlValue(new Yaml(loaderOptions).load(string))
 
     def parseYamls: Seq[YamlValue] =
-      new Yaml().loadAll(string).asScala.map(convertToYamlValue).toSeq
+      parseYamls(new LoaderOptions())
+
+    def parseYamls(loaderOptions: LoaderOptions) =
+      new Yaml(loaderOptions).loadAll(string).asScala.map(convertToYamlValue).toSeq
   }
 }


### PR DESCRIPTION
Hi @jcazevedo 

A critical exploit was [recently fixed in snakeyaml](https://bitbucket.org/asomov/snakeyaml/commits/da11ddbd91c1f8392ea932b37fa48110fa54ed8c) and released as part of 1.26. This PR upgrades snakeyaml to 1.26 and makes it possible to specify the LoaderOptions used when running parseYaml or parseYamls on a string.

Would love to see this merged and released as part of a new version of moultingyaml.

Thanks in advanced

Best regards

Simon, Denmark