### PR TITLE
make YF type alias public

### DIFF
--- a/src/main/scala/net/jcazevedo/moultingyaml/package.scala
+++ b/src/main/scala/net/jcazevedo/moultingyaml/package.scala
@@ -8,7 +8,7 @@ import scala.collection.JavaConverters._
 package object moultingyaml {
 
   // format: OFF
-  private[moultingyaml] type YF[A] = YamlFormat[A]
+  type YF[A] = YamlFormat[A]
   // format: ON
 
   case class DeserializationException(


### PR DESCRIPTION
Got the same issue as described [here](https://github.com/jcazevedo/moultingyaml/issues/48). To solve problem had to explicitly change YF to YamlFormatter. ISTM making YF public is another possible solution. This PR changes this.