### PR TITLE
update snakeYaml to 1.31

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12", "2.10.7")
 libraryDependencies ++= Seq(
   "com.github.nscala-time" %% "nscala-time"   % "2.22.0",
   "org.scala-lang"          % "scala-reflect" % scalaVersion.value,
-  "org.yaml"                % "snakeyaml"     % "1.26",
+  "org.yaml"                % "snakeyaml"     % "1.31",
   "org.scalatest"          %% "scalatest"     % "3.0.8"  % "test")
 
 scalacOptions ++= Seq(


### PR DESCRIPTION
There is currently a vulnerability in snakeYaml version 1.26.

Details can be found here:
https://www.mend.io/vulnerability-database/CVE-2022-38750

I would like to update the snakeYaml dependency to 1.31, which fixes this error.

Is there anything else I should do, like bump the version to 0.4.3 so that a new tag can be created?